### PR TITLE
Updates to Lithuanian TV24.lt channel

### DIFF
--- a/siteini.pack/Lithuania/tv24.lt.channels.xml
+++ b/siteini.pack/Lithuania/tv24.lt.channels.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V1.56.16 -- Jan van Straaten" site="tv24.lt">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V1.57 -- Jan van Straaten" site="tv24.lt">
   <channels>
     <channel update="i" site="tv24.lt" site_id="lrt-televizija" xmltv_id="LRT Televizija">LRT Televizija</channel>
     <channel update="i" site="tv24.lt" site_id="tv3-4" xmltv_id="TV3">TV3</channel>
@@ -24,8 +24,7 @@
     <channel update="i" site="tv24.lt" site_id="marijampoles-tv" xmltv_id="Marijampolės TV">Marijampolės TV</channel>
     <channel update="i" site="tv24.lt" site_id="siauliu-tv" xmltv_id="Šiaulių TV">Šiaulių TV</channel>
     <channel update="i" site="tv24.lt" site_id="zvaigzde" xmltv_id="Žvaigždė">Žvaigždė</channel>
-    <channel update="i" site="tv24.lt" site_id="splius" xmltv_id="Splius">Splius</channel>
-    <channel update="i" site="tv24.lt" site_id="pantv" xmltv_id="PanTV">PanTV</channel>
+    <channel update="i" site="tv24.lt" site_id="sony-sci-fi-russia" xmltv_id="Sony Sci-Fi Russia">Sony Sci-Fi Russia</channel>
     <channel update="i" site="tv24.lt" site_id="penki-tv" xmltv_id="Penki TV">Penki TV</channel>
     <channel update="i" site="tv24.lt" site_id="seimas-tiesiogiai" xmltv_id="Seimas tiesiogiai">Seimas tiesiogiai</channel>
     <channel update="i" site="tv24.lt" site_id="init-ekstra-tv" xmltv_id="Init Ekstra TV">Init Ekstra TV</channel>
@@ -42,20 +41,23 @@
     <channel update="i" site="tv24.lt" site_id="filmzone" xmltv_id="FILMZONE+">FILMZONE+</channel>
     <channel update="i" site="tv24.lt" site_id="bollywood-hd" xmltv_id="Bollywood HD">Bollywood HD</channel>
     <channel update="i" site="tv24.lt" site_id="zee-tv" xmltv_id="Zee TV">Zee TV</channel>
+    <channel update="i" site="tv24.lt" site_id="filmbox-baltic" xmltv_id="Filmbox Baltic">Filmbox Baltic</channel>
+    <channel update="i" site="tv24.lt" site_id="mgm-hd" xmltv_id="MGM HD">MGM HD</channel>
+    <channel update="i" site="tv24.lt" site_id="amc" xmltv_id="AMC">AMC</channel>
     <channel update="i" site="tv24.lt" site_id="viasat-sport-baltic" xmltv_id="Viasat Sport Baltic">Viasat Sport Baltic</channel>
+    <channel update="i" site="tv24.lt" site_id="viasat-os-4" xmltv_id="Viasat OS 4">Viasat OS 4</channel>
     <channel update="i" site="tv24.lt" site_id="eurosport-1" xmltv_id="Eurosport 1">Eurosport 1</channel>
     <channel update="i" site="tv24.lt" site_id="eurosport-2-bundesliga" xmltv_id="Eurosport 2 (Bundesliga)">Eurosport 2 (Bundesliga)</channel>
+    <channel update="i" site="tv24.lt" site_id="eurosport-2" xmltv_id="Eurosport 2">Eurosport 2</channel>
     <channel update="i" site="tv24.lt" site_id="setanta-eurasia" xmltv_id="Setanta Eurasia">Setanta Eurasia</channel>
     <channel update="i" site="tv24.lt" site_id="nba" xmltv_id="NBA">NBA</channel>
     <channel update="i" site="tv24.lt" site_id="extreme-sports" xmltv_id="Extreme Sports">Extreme Sports</channel>
     <channel update="i" site="tv24.lt" site_id="outdoor-hd" xmltv_id="Outdoor HD">Outdoor HD</channel>
-    <channel update="i" site="tv24.lt" site_id="viasat-motor" xmltv_id="Viasat Motor">Viasat Motor</channel>
     <channel update="i" site="tv24.lt" site_id="viasat-hockey" xmltv_id="Viasat Hockey">Viasat Hockey</channel>
     <channel update="i" site="tv24.lt" site_id="viasat-golf" xmltv_id="Viasat Golf">Viasat Golf</channel>
     <channel update="i" site="tv24.lt" site_id="drayv" xmltv_id="Драйв">Драйв</channel>
     <channel update="i" site="tv24.lt" site_id="avto-24" xmltv_id="Авто 24">Авто 24</channel>
     <channel update="i" site="tv24.lt" site_id="sport1" xmltv_id="Sport1">Sport1</channel>
-    <channel update="i" site="tv24.lt" site_id="eurosport-2" xmltv_id="Eurosport 2">Eurosport 2</channel>
     <channel update="i" site="tv24.lt" site_id="kkhl-tv" xmltv_id="КХЛ ТВ">КХЛ ТВ</channel>
     <channel update="i" site="tv24.lt" site_id="mtv-europe" xmltv_id="MTV Europe">MTV Europe</channel>
     <channel update="i" site="tv24.lt" site_id="mtv-dance" xmltv_id="MTV Dance">MTV Dance</channel>
@@ -105,24 +107,33 @@
     <channel update="i" site="tv24.lt" site_id="id-investigation-discovery" xmltv_id="ID Investigation Discovery">ID Investigation Discovery</channel>
     <channel update="i" site="tv24.lt" site_id="discovery-hd-showcase" xmltv_id="Discovery HD Showcase">Discovery HD Showcase</channel>
     <channel update="i" site="tv24.lt" site_id="animal-planet-hd" xmltv_id="Animal Planet HD">Animal Planet HD</channel>
+    <channel update="i" site="tv24.lt" site_id="discovery-dtx" xmltv_id="Discovery DTX">Discovery DTX</channel>
+    <channel update="i" site="tv24.lt" site_id="history2" xmltv_id="History2">History2</channel>
     <channel update="i" site="tv24.lt" site_id="bbc-world" xmltv_id="BBC World">BBC World</channel>
-    <channel update="i" site="tv24.lt" site_id="ltv1" xmltv_id="LTV1">LTV1</channel>
+    <channel update="i" site="tv24.lt" site_id="cnn" xmltv_id="CNN">CNN</channel>
+    <channel update="i" site="tv24.lt" site_id="euronews" xmltv_id="EuroNews">EuroNews</channel>
     <channel update="i" site="tv24.lt" site_id="tv3-3" xmltv_id="TV3+">TV3+</channel>
     <channel update="i" site="tv24.lt" site_id="sky-news" xmltv_id="Sky News">Sky News</channel>
     <channel update="i" site="tv24.lt" site_id="france-24-uk" xmltv_id="France 24 UK">France 24 UK</channel>
-    <channel update="i" site="tv24.lt" site_id="euronews" xmltv_id="EuroNews">EuroNews</channel>
-    <channel update="i" site="tv24.lt" site_id="cnn" xmltv_id="CNN">CNN</channel>
     <channel update="i" site="tv24.lt" site_id="da-vinci-learning" xmltv_id="Da Vinci Learning">Da Vinci Learning</channel>
     <channel update="i" site="tv24.lt" site_id="cnbc-europe" xmltv_id="CNBC Europe">CNBC Europe</channel>
     <channel update="i" site="tv24.lt" site_id="bloomberg" xmltv_id="Bloomberg">Bloomberg</channel>
     <channel update="i" site="tv24.lt" site_id="world-bussines-channel" xmltv_id="World Bussines Channel">World Bussines Channel</channel>
     <channel update="i" site="tv24.lt" site_id="tv5monde-europe" xmltv_id="TV5Monde Europe">TV5Monde Europe</channel>
+    <channel update="i" site="tv24.lt" site_id="rai-scuola" xmltv_id="RAI Scuola">RAI Scuola</channel>
+    <channel update="i" site="tv24.lt" site_id="uatv" xmltv_id="UA!??!TV">UA!??!TV</channel>
+    <channel update="i" site="tv24.lt" site_id="english-club-tv" xmltv_id="English Club TV">English Club TV</channel>
+    <channel update="i" site="tv24.lt" site_id="docubox" xmltv_id="DocuBox">DocuBox</channel>
+    <channel update="i" site="tv24.lt" site_id="cctv-news" xmltv_id="CCTV News">CCTV News</channel>
+    <channel update="i" site="tv24.lt" site_id="24h" xmltv_id="24h">24h</channel>
     <channel update="i" site="tv24.lt" site_id="playboy-tv-europe" xmltv_id="Playboy TV Europe">Playboy TV Europe</channel>
     <channel update="i" site="tv24.lt" site_id="blue-hustler" xmltv_id="Blue Hustler">Blue Hustler</channel>
     <channel update="i" site="tv24.lt" site_id="erox-hd" xmltv_id="Erox HD">Erox HD</channel>
+    <channel update="i" site="tv24.lt" site_id="fox-russia" xmltv_id="Fox Russia">Fox Russia</channel>
+    <channel update="i" site="tv24.lt" site_id="fox-life-russia" xmltv_id="Fox Life Russia">Fox Life Russia</channel>
     <channel update="i" site="tv24.lt" site_id="tlc-pan" xmltv_id="TLC Pan">TLC Pan</channel>
     <channel update="i" site="tv24.lt" site_id="sony-turbo-baltic" xmltv_id="Sony Turbo Baltic">Sony Turbo Baltic</channel>
-    <channel update="i" site="tv24.lt" site_id="sony-entertainment" xmltv_id="Sony Entertainment">Sony Entertainment</channel>
+    <channel update="i" site="tv24.lt" site_id="sony-channel" xmltv_id="Sony Channel">Sony Channel</channel>
     <channel update="i" site="tv24.lt" site_id="e-entertainment" xmltv_id="E! Entertainment">E! Entertainment</channel>
     <channel update="i" site="tv24.lt" site_id="fine-living-network" xmltv_id="Fine Living Network">Fine Living Network</channel>
     <channel update="i" site="tv24.lt" site_id="cbs-reality" xmltv_id="CBS Reality">CBS Reality</channel>
@@ -131,8 +142,14 @@
     <channel update="i" site="tv24.lt" site_id="fashion-one" xmltv_id="Fashion One">Fashion One</channel>
     <channel update="i" site="tv24.lt" site_id="arirang-tv" xmltv_id="Arirang TV">Arirang TV</channel>
     <channel update="i" site="tv24.lt" site_id="fashion-world" xmltv_id="Fashion World">Fashion World</channel>
+    <channel update="i" site="tv24.lt" site_id="zhivi" xmltv_id="Живи!">Живи!</channel>
+    <channel update="i" site="tv24.lt" site_id="inter" xmltv_id="Интер+">Интер+</channel>
     <channel update="i" site="tv24.lt" site_id="retro" xmltv_id="Ретро">Ретро</channel>
     <channel update="i" site="tv24.lt" site_id="rossiya-24" xmltv_id="Россия 24">Россия 24</channel>
+    <channel update="i" site="tv24.lt" site_id="tdk" xmltv_id="ТДК">ТДК</channel>
+    <channel update="i" site="tv24.lt" site_id="nauka-20" xmltv_id="Наука 2.0">Наука 2.0</channel>
+    <channel update="i" site="tv24.lt" site_id="mir-hd" xmltv_id="Мир HD">Мир HD</channel>
+    <channel update="i" site="tv24.lt" site_id="mir-24" xmltv_id="Мир 24">Мир 24</channel>
     <channel update="i" site="tv24.lt" site_id="deutche-welle" xmltv_id="Deutche Welle">Deutche Welle</channel>
     <channel update="i" site="tv24.lt" site_id="rtl" xmltv_id="RTL">RTL</channel>
     <channel update="i" site="tv24.lt" site_id="pro-7" xmltv_id="PRO 7">PRO 7</channel>

--- a/siteini.pack/Lithuania/tv24.lt.ini
+++ b/siteini.pack/Lithuania/tv24.lt.ini
@@ -3,6 +3,9 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: tv24.lt
 * @MinSWversion: V1.1.1/55
+* @Revision 6 - [12/02/2017] TDabasinskas
+*   Timezone was updated from UTC to Europe/Vilnius, which is the correct way to identify a timezone
+*   The space after each attribute was removed, as the site output was recently updated, causing the config to break
 * @Revision 5 - [06/08/2016] Blackbear199
 *	site changes
 * @Revision 4 - [19/07/2016] Blackbear199
@@ -21,27 +24,27 @@
 * @header_end
 **------------------------------------------------------------------------------------------------
 
-site {url=tv24.lt|timezone=UTC|maxdays=8|cultureinfo=lt-LT|charset=utf-8|titlematchfactor=90|episodesystem=onscreen|ratingsystem=IMDb}
-*url_index{url|https://www.tv24.lt/programme/listing/none/|urldate|?filter=channel&subslug=|channel|} *windows users
-url_index{url|http://127.0.0.1/tv24_lt.php?urldate=|urldate|&channel=|channel|} *linux users
+site {url=tv24.lt|timezone=Europe/Vilnius|maxdays=8|cultureinfo=lt-LT|charset=utf-8|titlematchfactor=90|episodesystem=onscreen|ratingsystem=IMDb}
+url_index{url|https://www.tv24.lt/programme/listing/none/|urldate|?filter=channel&subslug=|channel|} *windows users
+*url_index{url|http://127.0.0.1/tv24_lt.php?urldate=|urldate|&channel=|channel|} *linux users
 urldate.format {datestring|dd-MM-yyyy}
 url_index.headers {customheader=Accept-Encoding=gzip,deflate}
 url_index.headers {contenttype=application/json}
 *
 index_showsplit.scrub {multi||||} * copy content
 index_showsplit.modify {cleanup(style=jsondecode)}
-index_showsplit.modify {substring(type=regex)|"\"id\":\s\d{9}.*?\"logo_64\": \".*?\""}
+index_showsplit.modify {substring(type=regex)|"\"id\":\d{9}.*?\"logo_64\":\".*?\""}
 *index_showsplit.modify {replace|\||\n\n\|} *testing only
 *
 scope.range {(indexshowdetails)|end}
-index_start.scrub {single|"start_unix": ||,|,}
-index_stop.scrub {single|"stop_unix": ||,|,}
-index_title.scrub {single|"title": "||"|"}
+index_start.scrub {single|"start_unix":||,|,}
+index_stop.scrub {single|"stop_unix":||,|,}
+index_title.scrub {single|"title":"||"|"}
 *
-index_titleoriginal.scrub {regex||"title_original": "(.*?)",||}
+index_titleoriginal.scrub {regex||"title_original":"(.*?)",||}
 index_titleoriginal.modify {clear('index_titleoriginal' 'index_title')}
 *
-index_description.scrub {single|"description_long": "||"|"}
+index_description.scrub {single|"description_long":"||"|"}
 index_description.modify {replace|\\n| }
 index_description.modify {replace|\\t| }
 index_description.modify {replace|\\r| }
@@ -49,32 +52,32 @@ index_description.modify {cleanup}
 *
 index_subtitle.scrub {regex||"ep_title":"(.*?)",||}
 *
-index_category.scrub {regex||"genrestring": "(.*?)",||}
-index_category.scrub {regex||"categorystring": "(.*?)",||}
+index_category.scrub {regex||"genrestring":"(.*?)",||}
+index_category.scrub {regex||"categorystring":"(.*?)",||}
 index_category.modify {replace|,|\|} * make multi
 *
-index_country.scrub {single(separator=", ")|"country": "||"|"}
-index_productiondate.scrub {regex||"year": (\d{4}),||}
+index_country.scrub {single(separator=", ")|"country":"||"|"}
+index_productiondate.scrub {regex||"year":(\d{4}),||}
 *
-index_director.scrub {regex||"director": "(.*?)",||}
+index_director.scrub {regex||"director":"(.*?)",||}
 index_director.modify {replace|,|\|} * make multi
 *
-index_actor.scrub {regex||"cast": "(.*?)",||}
+index_actor.scrub {regex||"cast":"(.*?)",||}
 index_actor.modify {replace|,|\|} * make multi
 *
-index_showicon.scrub {regex||"image": "(https.+?)",||}
-index_urlchannellogo {url|https://cdn.tvstart.com/img/channel/|"logo_64": "||"|"}
+index_showicon.scrub {regex||"image":"(https.+?)",||}
+index_urlchannellogo {url|https://cdn.tvstart.com/img/channel/|"logo_64":"||"|"}
 *
-index_temp_1.scrub {single|"season": ||,|,}
+index_temp_1.scrub {single|"season":||,|,}
 index_temp_1.modify {clear("0")}
 index_temp_1.modify {addstart('index_temp_1' not "")|S}
 *
-index_episode.scrub {single|"ep_nr": ||,|,}
+index_episode.scrub {single|"ep_nr":||,|,}
 index_episode.modify {clear("0")}
 index_episode.modify {addstart('index_episode' not "")|E}
 index_episode.modify {addstart('index_temp_1' not "")|'index_temp_1'}
 *
-index_rating.scrub {single|"imdb_rating": ||,|,}
+index_rating.scrub {single|"imdb_rating":||,|,}
 index_rating.modify {replace|null|}
 end_scope
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _


### PR DESCRIPTION
- Timezone was updated from UTC to Europe/Vilnius, which is the correct way to identify a timezone
- The space after each attribute was removed, as the site output was recently updated, causing the config to break
- Channel list updated