### PR TITLE
Update yo.tv.ini

### DIFF
--- a/siteini.pack/International/yo.tv.ini
+++ b/siteini.pack/International/yo.tv.ini
@@ -3,6 +3,9 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: yo.tv
 * @MinSWversion:
+* @Revision 7 - [28/03/2017] Netuddki
+*	- Fixed bug in Titles
+*       - Improved Title
 * @Revision 6 - [25/03/2017] Netuddki
 *	- Revorked Titles
 *       - Added option for onscreen OR xmltv_ns episode system
@@ -52,7 +55,7 @@ urldate.format {daycounter|0}
 
 index_showsplit.scrub {regex||<a style(.*?)</a>||}
 index_start.scrub {regex||data-time='(.*?)'||}
-index_title.scrub {regex||<h2>(.*?)</h2>||}
+index_title.scrub {regex||<h2.*?>(.*?)</h2>||}
 index_title.modify {cleanup (tags="<"">")}
 index_subtitle.scrub {single (separator=": " exclude=first)|<h2|> | </h2>| <h3>}
 index_subtitle.modify {cleanup (tags="<"">")} *NEW
@@ -68,10 +71,11 @@ index_urlshow.headers {customheader=Accept-Encoding=gzip,deflate}     * to speed
 end_scope
 
 scope.range {(showdetails)|end}
-title.scrub {single|<div class='program'>|<h2>|</h2>|<h3>}
+title.scrub {regex||<div class='program'><h2.*?>(.*?)</h2>||}
 title.modify {cleanup (tags="<"">")}
 title.modify {remove (type=regex)|(\d+:\d+ am)}
 title.modify {remove (type=regex)|(\d+:\d+ pm)}
+title.modify {remove (type=regex)|(\(\d+\))}
 subtitle.scrub {single (separator=": " exclude=first)|<h2|>||</h2>}
 subtitle.modify {remove (type=regex)|(\s\(\d{4}\))}
 subtitle.modify {remove | </h2}


### PR DESCRIPTION
Sorry, I wasn't focused and didn't recognize that some titles are formatted differently, which caused titles being skipped.

Now it's fixed.