### PR TITLE
mediaset premium

### DIFF
--- a/siteini.pack/Italy/fineliving.it.channels.xml
+++ b/siteini.pack/Italy/fineliving.it.channels.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.0.5 -- Jan van Straaten" site="fineliving.it">
+  <channels>
+    <channel update="i" site="fineliving.it" site_id="fineliving" xmltv_id="Fineliving">Fineliving</channel>
+  </channels>
+</site>

--- a/siteini.pack/Italy/fineliving.it.channels.xml
+++ b/siteini.pack/Italy/fineliving.it.channels.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.0.5 -- Jan van Straaten" site="fineliving.it">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.0.6 -- Jan van Straaten" site="fineliving.it">
   <channels>
-    <channel update="i" site="fineliving.it" site_id="fineliving" xmltv_id="Fineliving">Fineliving</channel>
+    <channel update="i" site="fineliving.it" site_id="" xmltv_id="Fine Living Italia">Fine Living Italia</channel>
   </channels>
 </site>

--- a/siteini.pack/Italy/fineliving.it.ini
+++ b/siteini.pack/Italy/fineliving.it.ini
@@ -10,12 +10,11 @@
 **------------------------------------------------------------------------------------------------
 site {url=fineliving.it|timezone=Europe/Rome|maxdays=14|cultureinfo=it-IT|charset=UTF-8|nopageoverlaps|titlematchfactor=90}
 site {episodesystem=onscreen|}
-*firstday=0123456
+
 url_index{url|http://www.fineliving.it/guida-tv}
 url_index.headers {customheader=Accept-Encoding=gzip,deflate}
 urldate.format {datestring|dd-MM-yyyy}
-*urldate.format {datestring|yyyy-MM-dd}
-*urldate.format {daycounter|0}
+index_urlchannellogo.modify {addstart|http://cms.supadu.com/images/working2/s816965/2.png}
 *
 index_showsplit.scrub {multi(excludeblock=<script type="text/javascript">)|<div class="details row">||</div></div></div>}
 index_start.scrub {regex||(\d{2}:\d{2})\s</div>||}
@@ -27,7 +26,7 @@ index_description.scrub {regex||<div class="short-description">(.*?)</div>||}
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
 **
 ** @auto_xml_channel_start
-index_site_id.scrub {|}
-index_site_id.modify {set|fineliving}
-index_site_channel.modify {set|Fineliving}
+*url_index{url|http://www.fineliving.it/guida-tv}
+*index_site_id.scrub {single|<script type="text/javascript"!src="http://www.|scripts.js">|</script>}
+*index_site_channel.scrub {single|</script>|programmi TV|</title>}
 ** @auto_xml_channel_end

--- a/siteini.pack/Italy/fineliving.it.ini
+++ b/siteini.pack/Italy/fineliving.it.ini
@@ -1,0 +1,33 @@
+**------------------------------------------------------------------------------------------------
+* @header_start
+* WebGrab+Plus ini for grabbing EPG data from TvGuide websites
+* @Site: fineliving.it
+* @MinSWversion: V1.1.1/56.29
+* @Revision 0 - [23/03/2017] mat8861 & BlackBear
+*  - creation
+* @Remarks: weekly schedule monday-friday
+* @header_end
+**------------------------------------------------------------------------------------------------
+site {url=fineliving.it|timezone=Europe/Rome|maxdays=14|cultureinfo=it-IT|charset=UTF-8|nopageoverlaps|titlematchfactor=90}
+site {episodesystem=onscreen|}
+*firstday=0123456
+url_index{url|http://www.fineliving.it/guida-tv}
+url_index.headers {customheader=Accept-Encoding=gzip,deflate}
+urldate.format {datestring|dd-MM-yyyy}
+*urldate.format {datestring|yyyy-MM-dd}
+*urldate.format {daycounter|0}
+*
+index_showsplit.scrub {multi(excludeblock=<script type="text/javascript">)|<div class="details row">||</div></div></div>}
+index_start.scrub {regex||(\d{2}:\d{2})\s</div>||}
+index_title.scrub {regex||<p class="episode-title">(.*?)</p>||}
+index_description.scrub {regex||<div class="short-description">(.*?)</div>||}
+
+
+**  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
+**      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
+**
+** @auto_xml_channel_start
+index_site_id.scrub {|}
+index_site_id.modify {set|fineliving}
+index_site_channel.modify {set|Fineliving}
+** @auto_xml_channel_end

--- a/siteini.pack/Italy/mediasetpremium.it.channels.xml
+++ b/siteini.pack/Italy/mediasetpremium.it.channels.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version 1.1.1/55.27 -- Jan van Straaten" site="mediasetpremium.it">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V1.57 -- Jan van Straaten" site="mediasetpremium.it">
   <channels>
     <channel update="i" site="mediasetpremium.it" site_id="KE" xmltv_id="Premium Cinema HD">Premium Cinema HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LX" xmltv_id="Premium Cinema +24">Premium Cinema +24</channel>
@@ -17,6 +17,7 @@
     <channel update="i" site="mediasetpremium.it" site_id="KD" xmltv_id="Premium Stories">Premium Stories</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LV" xmltv_id="Premium Sport HD">Premium Sport HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KC" xmltv_id="Premium Calcio HD">Premium Calcio HD</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="EH" xmltv_id="Investigation Discovery">Investigation Discovery</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EE" xmltv_id="Eurosport">Eurosport</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EF" xmltv_id="Eurosport 2">Eurosport 2</channel>
     <channel update="i" site="mediasetpremium.it" site_id="ED" xmltv_id="Discovery World">Discovery World</channel>
@@ -26,5 +27,6 @@
     <channel update="i" site="mediasetpremium.it" site_id="KP" xmltv_id="Disney Junior">Disney Junior</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KN" xmltv_id="Cartoon Network">Cartoon Network</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KU" xmltv_id="PLAY">PLAY</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="K1" xmltv_id="Premium Calcio 1 HD">Premium Calcio 1 HD</channel>
   </channels>
 </site>

--- a/siteini.pack/Italy/mediasetpremium.it.channels.xml
+++ b/siteini.pack/Italy/mediasetpremium.it.channels.xml
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V1.57 -- Jan van Straaten" site="mediasetpremium.it">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.0.6 -- Jan van Straaten" site="mediasetpremium.it">
   <channels>
     <channel update="i" site="mediasetpremium.it" site_id="KE" xmltv_id="Premium Cinema HD">Premium Cinema HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LX" xmltv_id="Premium Cinema +24">Premium Cinema +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LM" xmltv_id="Premium Cinema 2 HD">Premium Cinema 2 HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LW" xmltv_id="Premium Cinema 2 +24">Premium Cinema 2 +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KG" xmltv_id="Premium Cinema Energy">Premium Cinema Energy</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="LQ" xmltv_id="Premium Cinema Energy +24">Premium Cinema Energy +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KO" xmltv_id="Premium Cinema Emotion">Premium Cinema Emotion</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LC" xmltv_id="Premium Cinema Comedy">Premium Cinema Comedy</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KR" xmltv_id="Studio Universal">Studio Universal</channel>
@@ -14,19 +15,16 @@
     <channel update="i" site="mediasetpremium.it" site_id="LR" xmltv_id="Premium Crime HD">Premium Crime HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LZ" xmltv_id="Premium Crime +24">Premium Crime +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KJ" xmltv_id="Premium Joi">Premium Joi</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="LD" xmltv_id="Premium Joi +24">Premium Joi +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KD" xmltv_id="Premium Stories">Premium Stories</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="LV" xmltv_id="Premium Sport HD">Premium Sport HD</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="KC" xmltv_id="Premium Calcio HD">Premium Calcio HD</channel>
+	<channel update="i" site="mediasetpremium.it" site_id="LE" xmltv_id="Premium Stories +24">Premium Stories +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EH" xmltv_id="Investigation Discovery">Investigation Discovery</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="LV" xmltv_id="Premium Sport HD">Premium Sport HD</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="KC" xmltv_id="Premium Sport 2 HD">Premium Sport 2 HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EE" xmltv_id="Eurosport">Eurosport</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EF" xmltv_id="Eurosport 2">Eurosport 2</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="ED" xmltv_id="Discovery World">Discovery World</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="EB" xmltv_id="BBC Knowledge">BBC Knowledge</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="DY" xmltv_id="Disney Channel">Disney Channel</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="DZ" xmltv_id="Disney Channel +1">Disney Channel +1</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="KP" xmltv_id="Disney Junior">Disney Junior</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KN" xmltv_id="Cartoon Network">Cartoon Network</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="KU" xmltv_id="PLAY">PLAY</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="KC" xmltv_id="Premium Calcio HD">Premium Calcio HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="K1" xmltv_id="Premium Calcio 1 HD">Premium Calcio 1 HD</channel>
   </channels>
 </site>

--- a/siteini.pack/Italy/mediasetpremium.it.channels.xml
+++ b/siteini.pack/Italy/mediasetpremium.it.channels.xml
@@ -14,17 +14,15 @@
     <channel update="i" site="mediasetpremium.it" site_id="LU" xmltv_id="Premium Action +24">Premium Action +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LR" xmltv_id="Premium Crime HD">Premium Crime HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LZ" xmltv_id="Premium Crime +24">Premium Crime +24</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="KD" xmltv_id="Premium Stories">Premium Stories</channel>
+    <channel update="i" site="mediasetpremium.it" site_id="LE" xmltv_id="Premium Stories +24">Premium Stories +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KJ" xmltv_id="Premium Joi">Premium Joi</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LD" xmltv_id="Premium Joi +24">Premium Joi +24</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="KD" xmltv_id="Premium Stories">Premium Stories</channel>
-	<channel update="i" site="mediasetpremium.it" site_id="LE" xmltv_id="Premium Stories +24">Premium Stories +24</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EH" xmltv_id="Investigation Discovery">Investigation Discovery</channel>
     <channel update="i" site="mediasetpremium.it" site_id="LV" xmltv_id="Premium Sport HD">Premium Sport HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KC" xmltv_id="Premium Sport 2 HD">Premium Sport 2 HD</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EE" xmltv_id="Eurosport">Eurosport</channel>
     <channel update="i" site="mediasetpremium.it" site_id="EF" xmltv_id="Eurosport 2">Eurosport 2</channel>
     <channel update="i" site="mediasetpremium.it" site_id="KN" xmltv_id="Cartoon Network">Cartoon Network</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="KC" xmltv_id="Premium Calcio HD">Premium Calcio HD</channel>
-    <channel update="i" site="mediasetpremium.it" site_id="K1" xmltv_id="Premium Calcio 1 HD">Premium Calcio 1 HD</channel>
   </channels>
 </site>

--- a/siteini.pack/Italy/mediasetpremium.it.ini
+++ b/siteini.pack/Italy/mediasetpremium.it.ini
@@ -3,6 +3,7 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: mediasetpremium.it
 * @MinSWversion: V1.1.1/55.26
+* @Revision 2 - [31/05/2017] Mat8861 *fix channel creation
 * @Revision 1 - [18/10/2015] Jan van Straaten
 * added rating conversion, plus one hour offset in the times!?
 * @Revision 0 - [27/08/2015] Jan van Straaten
@@ -56,9 +57,9 @@ actor.modify {replace|,|\|} * make multi
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
 **
 ** @auto_xml_channel_start
-*url_index {url|http://www.mediasetpremium.it/inc/css/layout.css}
-*index_site_id.scrub {regex||\r\n\d{1,2}\..+?\s{2,3}(\w{2})||}
-*index_site_channel.scrub {regex||\r\n\d{1,2}\.\s+?(.+?)\s{2,3}||}
+*url_index {url|http://www.mediasetpremium.it/guida_tv/json/config.json}
+*index_site_id.scrub {multi|"channels"|"channelid":"|"|,]}]}
+*index_site_channel.scrub{multi|"channels"|"label":"|"|,]}]}
 *scope.range {(channellist)|end}
 *index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}
 *end_scope

--- a/siteini.pack/UK/finelivingnetwork.com.channels.xml
+++ b/siteini.pack/UK/finelivingnetwork.com.channels.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.0.6 -- Jan van Straaten" site="finelivingnetwork.com">
+  <channels>
+    <channel update="i" site="finelivingnetwork.com" site_id="" xmltv_id="Fine Living">Fine Living</channel>
+  </channels>
+</site>

--- a/siteini.pack/UK/finelivingnetwork.com.ini
+++ b/siteini.pack/UK/finelivingnetwork.com.ini
@@ -1,0 +1,34 @@
+**------------------------------------------------------------------------------------------------
+* @header_start
+* WebGrab+Plus ini for grabbing EPG data from TvGuide websites
+* @Site: finelivingnetwork.com
+* @MinSWversion: V1.1.1/56.29
+* @Revision 0 - [23/03/2017] mat8861 & BlackBear199
+*  - creation
+* @Remarks: 
+* @header_end
+**------------------------------------------------------------------------------------------------
+site {url=finelivingnetwork.com|timezone=Europe/London|maxdays=7|cultureinfo=en-GB|charset=UTF-8|nopageoverlaps|titlematchfactor=90}
+site {episodesystem=onscreen|}
+
+url_index{url|http://www.finelivingnetwork.com/tv-guide}
+url_index.headers {customheader=Accept-Encoding=gzip,deflate}
+urldate.format {datestring|dd-MM-yyyy}
+index_urlchannellogo.modify {addstart|http://cms.supadu.com/images/working2/s816965/2.png}
+*
+index_showsplit.scrub {multi(excludeblock=<script type="text/javascript">)|<div class="details row">||</div></div></div>}
+index_start.scrub {regex||(\d{2}:\d{2})\s</div>||}
+index_start.modify {replace|24:|00:}
+index_start.modify {replace|25:|01:}
+index_start.modify {replace|26:|02:}
+index_title.scrub {regex||<p class="episode-title">(.*?)</p>||}
+index_description.scrub {regex||<div class="short-description">(.*?)</div>||}
+
+**  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
+**      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
+**
+** @auto_xml_channel_start
+*url_index{url|http://www.finelivingnetwork.com/tv-guide}
+*index_site_id.scrub {single|<script type="text/javascript"!src="http://www.|scripts.js">|</script>}
+*index_site_channel.scrub {single|</script>|<title>| EMEA|</title>}
+** @auto_xml_channel_end


### PR DESCRIPTION
Mediaset Premium : After checking channels also in the website download (pdf @ http://www.mediasetpremium.it/bin/66.$plit/C_54_download_guida_tv_2_elenco_guide_List218_itemName0_pdf_guida.pdf ) it looks it is correct. Old channel are marked on website as /MAY BE DEAD/ and the correct ones are from the active json code webpage. Probably old ones are being deleted as there is no epg downloaded for those channels. 
Additionaly there is a new page now for soccer (calcio) a separate ini should be made, but is constantly changed and is an irregular mix of sportHD, sport and CalcioHd -Calcio1 lately no shows on calcio 2-3-4-5-6-7.