### PR TITLE
Update tv24.lt.ini

### DIFF
--- a/siteini.pack/Lithuania/tv24.lt.ini
+++ b/siteini.pack/Lithuania/tv24.lt.ini
@@ -3,6 +3,8 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: tv24.lt
 * @MinSWversion: V1.1.1/55
+* @Revision 7 - [08/01/2018] TDabasinskas
+*   Timezone changed backed to UTC, as the UNIX timestamps within the parsed text are UTC based.
 * @Revision 6 - [12/02/2017] TDabasinskas
 *   Timezone was updated from UTC to Europe/Vilnius, which is the correct way to identify a timezone
 *   The space after each attribute was removed, as the site output was recently updated, causing the config to break
@@ -24,7 +26,7 @@
 * @header_end
 **------------------------------------------------------------------------------------------------
 
-site {url=tv24.lt|timezone=Europe/Vilnius|maxdays=8|cultureinfo=lt-LT|charset=utf-8|titlematchfactor=90|episodesystem=onscreen|ratingsystem=IMDb}
+site {url=tv24.lt|timezone=UTC|maxdays=8|cultureinfo=lt-LT|charset=utf-8|titlematchfactor=90|episodesystem=onscreen|ratingsystem=IMDb}
 url_index{url|https://www.tv24.lt/programme/listing/none/|urldate|?filter=channel&subslug=|channel|} *windows users
 *url_index{url|http://127.0.0.1/tv24_lt.php?urldate=|urldate|&channel=|channel|} *linux users
 urldate.format {datestring|dd-MM-yyyy}


### PR DESCRIPTION
Changing the timezone back to UTC, as, even the page displays times in Europe/Vilnius timezone, the UNIX timestamps parsed from the page are UTC-based.