### PR TITLE
Add new configuration and channels for tvtv.us

### DIFF
--- a/siteini.pack/USA/tvtv.us.channels.xml
+++ b/siteini.pack/USA/tvtv.us.channels.xml
@@ -1,0 +1,568 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V2.1 -- Jan van Straaten" site="tvtv.us">
+  <channels>
+    <channel update="i" site="tvtv.us" site_id="36212D/1766" xmltv_id="CBS (WCBS) New York, NY">CBS (WCBS) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1767" xmltv_id="NBC (WNBC) New York, NY">NBC (WNBC) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1638" xmltv_id="FOX (WNYW) New York, NY">FOX (WNYW) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1769" xmltv_id="ABC (WABC) New York, NY">ABC (WABC) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1612" xmltv_id="MNT (WWOR) New York, NY">MNT (WWOR) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/63" xmltv_id="WPIX New York (SUPERSTATION)">WPIX New York (SUPERSTATION)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1774" xmltv_id="PBS (WNET) New York, NY">PBS (WNET) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1775" xmltv_id="PBS (WLIW) Long Island, NY">PBS (WLIW) Long Island, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10011" xmltv_id="NYC Life (WNYE-DT1) New York, NY">NYC Life (WNYE-DT1) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1778" xmltv_id="ION (WPXN) New York, NY">ION (WPXN) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/5138" xmltv_id="MeTV (WJLP) New Jersey\/New York">MeTV (WJLP) New Jersey\/New York</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11536" xmltv_id="Azteca (WMBC) Newton, NJ">Azteca (WMBC) Newton, NJ</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1771" xmltv_id="UNI (WXTV) Teaneck, NJ">UNI (WXTV) Teaneck, NJ</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11337" xmltv_id="SonLife (WZME) Bridgeport, CT">SonLife (WZME) Bridgeport, CT</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1772" xmltv_id="Telemundo (WNJU) Teterboro, NJ">Telemundo (WNJU) Teterboro, NJ</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2065" xmltv_id="Connecticut Public Television (WEDW) Bridgeport">Connecticut Public Television (WEDW) Bridgeport</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2574" xmltv_id="New Jersey PBS (WNJN) Montclair, NJ">New Jersey PBS (WNJN) Montclair, NJ</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9574" xmltv_id="WLNY TV10\/55, Riverhead, NY">WLNY TV10\/55, Riverhead, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4689" xmltv_id="RNN (WRNN) Kingston, NY">RNN (WRNN) Kingston, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2561" xmltv_id="WMBC-Newton, NJ">WMBC-Newton, NJ</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7289" xmltv_id="MHz Worldview (WNYJ-DT2) Milford, NJ">MHz Worldview (WNYJ-DT2) Milford, NJ</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1776" xmltv_id="UniM\u00e1s (WFUT) New York, NY">UniM\u00e1s (WFUT) New York, NY</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14683" xmltv_id="QVC">QVC</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/329" xmltv_id="Game Show Network - East">Game Show Network - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3000" xmltv_id="Jewelry Television">Jewelry Television</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1523" xmltv_id="EVINE">EVINE</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/13442" xmltv_id="QVC2">QVC2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18865" xmltv_id="Audience Network">Audience Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/20224" xmltv_id="DirecTV Sports 121">DirecTV Sports 121</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/20225" xmltv_id="DirecTV Sports 122">DirecTV Sports 122</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/20368" xmltv_id="DirecTV Sports 123">DirecTV Sports 123</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/20369" xmltv_id="DirecTV Sports 124">DirecTV Sports 124</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/70" xmltv_id="CNN">CNN</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/425" xmltv_id="HLN">HLN</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/594" xmltv_id="ESPN">ESPN</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1527" xmltv_id="ESPN News">ESPN News</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3331" xmltv_id="ESPN U">ESPN U</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/650" xmltv_id="ESPN2">ESPN2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9051" xmltv_id="ESPN2 (Alternate)">ESPN2 (Alternate)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3349" xmltv_id="NFL Network">NFL Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6178" xmltv_id="MLB Network">MLB Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6610" xmltv_id="MavTV USA">MavTV USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14156" xmltv_id="NHL Network USA">NHL Network USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18833" xmltv_id="NHL Network USA Alternate">NHL Network USA Alternate</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3116" xmltv_id="NBA TV USA">NBA TV USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2269" xmltv_id="The Tennis Channel">The Tennis Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/193" xmltv_id="Golf Channel USA">Golf Channel USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/668" xmltv_id="Fox Sports 1">Fox Sports 1</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1386" xmltv_id="NBC Sports Network">NBC Sports Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3115" xmltv_id="CBS Sports Network USA">CBS Sports Network USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4546" xmltv_id="Gem Shopping Network">Gem Shopping Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/623" xmltv_id="HGTV USA - Eastern Feed">HGTV USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/622" xmltv_id="Do It Yourself Network (USA) - East">Do It Yourself Network (USA) - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1054" xmltv_id="Food Network USA - Eastern Feed">Food Network USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4226" xmltv_id="The Cooking Channel">The Cooking Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/617" xmltv_id="E! Entertainment USA - Eastern Feed">E! Entertainment USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/646" xmltv_id="Bravo USA - Eastern Feed">Bravo USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4175" xmltv_id="ReelzChannel">ReelzChannel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14985" xmltv_id="HSN  - Home Shopping Network">HSN  - Home Shopping Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1030" xmltv_id="Paramount Network USA - Eastern Feed">Paramount Network USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/640" xmltv_id="USA Network - East Feed">USA Network - East Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/596" xmltv_id="Syfy - Eastern Feed">Syfy - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/347" xmltv_id="TNT - Eastern Feed">TNT - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/333" xmltv_id="truTV USA - Eastern">truTV USA - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/61" xmltv_id="TBS - East">TBS - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/652" xmltv_id="FX Networks East Coast">FX Networks East Coast</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/647" xmltv_id="Comedy Central (US) - Eastern Feed">Comedy Central (US) - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/659" xmltv_id="Oxygen - Eastern Feed">Oxygen - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/654" xmltv_id="Lifetime Network US - Eastern Feed">Lifetime Network US - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1333" xmltv_id="Lifetime Movies - East">Lifetime Movies - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/177" xmltv_id="AMC - Eastern Feed">AMC - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/176" xmltv_id="Turner Classic Movies USA">Turner Classic Movies USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1308" xmltv_id="FX Movie Channel">FX Movie Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1952" xmltv_id="FXX USA - Eastern">FXX USA - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/664" xmltv_id="WE (Womens Entertainment) - Eastern">WE (Womens Entertainment) - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1273" xmltv_id="Discovery Life Channel">Discovery Life Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/615" xmltv_id="BBC America - East">BBC America - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2" xmltv_id="A&amp;E US - Eastern Feed">A&amp;E US - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1971" xmltv_id="FYI USA - Eastern">FYI USA - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/621" xmltv_id="History Channel US - Eastern Feed">History Channel US - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/624" xmltv_id="Viceland USA">Viceland USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2091" xmltv_id="LOGO - East">LOGO - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10165" xmltv_id="POP - East">POP - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2267" xmltv_id="Ovation">Ovation</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/657" xmltv_id="National Geographic US - Eastern">National Geographic US - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/662" xmltv_id="Travel US - East">Travel US - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/649" xmltv_id="Discovery Channel (US) - Eastern Feed">Discovery Channel (US) - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1159" xmltv_id="Oprah Winfrey Network USA Eastern">Oprah Winfrey Network USA Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/5005" xmltv_id="TLC USA - Eastern">TLC USA - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/12597" xmltv_id="Velocity HD">Velocity HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/645" xmltv_id="Animal Planet US - East">Animal Planet US - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7537" xmltv_id="National Geographic Wild">National Geographic Wild</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1960" xmltv_id="Science">Science</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2090" xmltv_id="Investigation Discovery USA - Eastern">Investigation Discovery USA - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2074" xmltv_id="Destination America">Destination America</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2035" xmltv_id="American Heroes Channel">American Heroes Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6867" xmltv_id="Disney Junior USA - East">Disney Junior USA - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/595" xmltv_id="Disney - Eastern Feed">Disney - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1271" xmltv_id="Disney - Pacific Feed">Disney - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1053" xmltv_id="Disney XD USA - Eastern Feed">Disney XD USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4444" xmltv_id="Baby First TV">Baby First TV</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4225" xmltv_id="Discovery Family Channel">Discovery Family Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4349" xmltv_id="Universal Kids">Universal Kids</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/661" xmltv_id="Cartoon Network USA - Eastern Feed">Cartoon Network USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1209" xmltv_id="Cartoon Network USA - Pacific Feed">Cartoon Network USA - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2268" xmltv_id="Boomerang">Boomerang</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/658" xmltv_id="Nickelodeon USA - East Feed">Nickelodeon USA - East Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1198" xmltv_id="Nickelodeon USA - Pacific Feed">Nickelodeon USA - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1969" xmltv_id="Nick Jr. - East">Nick Jr. - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2010" xmltv_id="Nicktoons - East">Nicktoons - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1954" xmltv_id="TeenNick - Eastern">TeenNick - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1252" xmltv_id="TV Land - Eastern">TV Land - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1274" xmltv_id="ION  - Eastern Feed">ION  - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1923" xmltv_id="ION  - Pacific Feed">ION  - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/65" xmltv_id="WGN America - Eastern Feed">WGN America - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1011" xmltv_id="Freeform - East Feed">Freeform - East Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1052" xmltv_id="Hallmark - Eastern Feed">Hallmark - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1051" xmltv_id="GAC - Great American Country">GAC - Great American Country</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1076" xmltv_id="CMT US - Eastern Feed">CMT US - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2287" xmltv_id="TV One">TV One</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/323" xmltv_id="BET - Eastern Feed">BET - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6837" xmltv_id="BET Her">BET Her</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/656" xmltv_id="MTV USA - Eastern Feed">MTV USA - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1515" xmltv_id="MTV 2 - East">MTV 2 - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/663" xmltv_id="VH1 - Eastern Feed">VH1 - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2093" xmltv_id="MTV Classic - East">MTV Classic - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/5911" xmltv_id="UP">UP</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1486" xmltv_id="FUSE TV - Eastern feed">FUSE TV - Eastern feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/20067" xmltv_id="AXS TV USA HD">AXS TV USA HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11399" xmltv_id="El Rey Network">El Rey Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11364" xmltv_id="Fusion HD">Fusion HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11294" xmltv_id="Fusion">Fusion</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9388" xmltv_id="SonLife Network">SonLife Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2673" xmltv_id="RFD-TV">RFD-TV</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10294" xmltv_id="BBC World HD">BBC World HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4541" xmltv_id="Free Speech Network">Free Speech Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16818" xmltv_id="NewsMax TV">NewsMax TV</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/648" xmltv_id="CSPAN">CSPAN</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1050" xmltv_id="CSPAN 2">CSPAN 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1963" xmltv_id="NASA Public Educational Channel">NASA Public Educational Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1856" xmltv_id="Bloomberg TV USA">Bloomberg TV USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/201" xmltv_id="CNBC USA">CNBC USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/655" xmltv_id="MSNBC USA">MSNBC USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2664" xmltv_id="CNBC World">CNBC World</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4656" xmltv_id="Fox Business">Fox Business</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1083" xmltv_id="Fox News">Fox News</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/13501" xmltv_id="WeatherNation">WeatherNation</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1526" xmltv_id="The Weather Channel">The Weather Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4455" xmltv_id="GEB America">GEB America</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1082" xmltv_id="INSP">INSP</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6825" xmltv_id="God TV USA">God TV USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6826" xmltv_id="Jewish Life Television">Jewish Life Television</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6038" xmltv_id="World Harvest Television">World Harvest Television</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6827" xmltv_id="Hope Channel">Hope Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6828" xmltv_id="Daystar  - Network">Daystar  - Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/620" xmltv_id="EWTN USA">EWTN USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14962" xmltv_id="Hillsong (K64FT) Alexandria, LA">Hillsong (K64FT) Alexandria, LA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1119" xmltv_id="TBN  - Trinity Broadcasting Network - East">TBN  - Trinity Broadcasting Network - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/13473" xmltv_id="The Word Network">The Word Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3332" xmltv_id="BYU (Brigham Young University)">BYU (Brigham Young University)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11131" xmltv_id="CTN - Christian Television Network">CTN - Christian Television Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3709" xmltv_id="TCT - Network">TCT - Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4547" xmltv_id="National Religious Broadcasting - East">National Religious Broadcasting - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9018" xmltv_id="Impact Television Network">Impact Television Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14995" xmltv_id="Comedy.TV">Comedy.TV</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14993" xmltv_id="Justice Central">Justice Central</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4259" xmltv_id="PBS - Network HD - Eastern">PBS - Network HD - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2172" xmltv_id="CBS (KCBS) Los Angeles, CA">CBS (KCBS) Los Angeles, CA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2588" xmltv_id="NBC (KNBC) Los Angeles, CA">NBC (KNBC) Los Angeles, CA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3120" xmltv_id="CW (WDCW) District of Columbia">CW (WDCW) District of Columbia</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10264" xmltv_id="CW (KFMB-TV2) San Diego, CA">CW (KFMB-TV2) San Diego, CA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2589" xmltv_id="ABC (KABC) Los Angeles, CA">ABC (KABC) Los Angeles, CA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1949" xmltv_id="FOX (KTTV) Los Angeles, CA">FOX (KTTV) Los Angeles, CA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1305" xmltv_id="Univision - Eastern Feed">Univision - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1306" xmltv_id="Univision - Pacific Feed">Univision - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1894" xmltv_id="Galavision - Eastern Feed">Galavision - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1521" xmltv_id="Telemundo  - Eastern Feed">Telemundo  - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2013" xmltv_id="Telemundo  - Pacific Feed">Telemundo  - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/17006" xmltv_id="UniM\u00e1s  - Network Pacific">UniM\u00e1s  - Network Pacific</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1797" xmltv_id="NBC Universo - Eastern feed">NBC Universo - Eastern feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2073" xmltv_id="Discovery en Espanol">Discovery en Espanol</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2096" xmltv_id="CNN Espa\u00f1ol">CNN Espa\u00f1ol</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6833" xmltv_id="Telecentro">Telecentro</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18869" xmltv_id="Per\u00fa M\u00e1gico">Per\u00fa M\u00e1gico</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8898" xmltv_id="V-Me Television HD">V-Me Television HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2142" xmltv_id="Azteca America - East">Azteca America - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3256" xmltv_id="Enlace">Enlace</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11145" xmltv_id="Uni Deportes">Uni Deportes</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1827" xmltv_id="Fox Deportes">Fox Deportes</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2108" xmltv_id="ESPN Deportes">ESPN Deportes</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10855" xmltv_id="beIN Sport en Espanol">beIN Sport en Espanol</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11505" xmltv_id="Gol TV USA">Gol TV USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4578" xmltv_id="TyC Sports">TyC Sports</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10807" xmltv_id="Spectrum Deportes">Spectrum Deportes</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19239" xmltv_id="DirecTV MLS Direct Kick (471) HD">DirecTV MLS Direct Kick (471) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19238" xmltv_id="DirecTV MLS Direct Kick (471)">DirecTV MLS Direct Kick (471)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19240" xmltv_id="DirecTV MLS Direct Kick (472)">DirecTV MLS Direct Kick (472)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19241" xmltv_id="DirecTV MLS Direct Kick (472) HD">DirecTV MLS Direct Kick (472) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19242" xmltv_id="DirecTV MLS Direct Kick (473)">DirecTV MLS Direct Kick (473)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19243" xmltv_id="DirecTV MLS Direct Kick (473) HD">DirecTV MLS Direct Kick (473) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19245" xmltv_id="DirecTV MLS Direct Kick (474) HD">DirecTV MLS Direct Kick (474) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19244" xmltv_id="DirecTV MLS Direct Kick (474)">DirecTV MLS Direct Kick (474)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19246" xmltv_id="DirecTV MLS Direct Kick (475)">DirecTV MLS Direct Kick (475)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19247" xmltv_id="DirecTV MLS Direct Kick (475) HD">DirecTV MLS Direct Kick (475) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19248" xmltv_id="DirecTV MLS Direct Kick (476)">DirecTV MLS Direct Kick (476)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19249" xmltv_id="DirecTV MLS Direct Kick (476) HD">DirecTV MLS Direct Kick (476) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31696" xmltv_id="DirecTV MLS Direct Kick (477) HD">DirecTV MLS Direct Kick (477) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31695" xmltv_id="DirecTV MLS Direct Kick (477)">DirecTV MLS Direct Kick (477)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/32674" xmltv_id="DirecTV MLS Direct Kick (478) HD">DirecTV MLS Direct Kick (478) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/32672" xmltv_id="DirecTV MLS Direct Kick (478)">DirecTV MLS Direct Kick (478)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/32673" xmltv_id="DirecTV MLS Direct Kick (479)">DirecTV MLS Direct Kick (479)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/32675" xmltv_id="DirecTV MLS Direct Kick (479) HD">DirecTV MLS Direct Kick (479) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16675" xmltv_id="Premier League Extra Time 1">Premier League Extra Time 1</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16676" xmltv_id="Premier League Extra Time 2">Premier League Extra Time 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16677" xmltv_id="Premier League Extra Time 3">Premier League Extra Time 3</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16678" xmltv_id="Premier League Extra Time 4">Premier League Extra Time 4</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16679" xmltv_id="Premier League Extra Time 5">Premier League Extra Time 5</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/614" xmltv_id="HBO - Eastern Feed">HBO - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/626" xmltv_id="HBO 2 - Eastern Feed">HBO 2 - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1651" xmltv_id="HBO Signature (HBO 3) - Eastern">HBO Signature (HBO 3) - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1472" xmltv_id="HBO - Pacific Feed">HBO - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2205" xmltv_id="HBO 2 - Pacific Feed">HBO 2 - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7105" xmltv_id="HBO Comedy HD - East">HBO Comedy HD - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/628" xmltv_id="HBO Family - Eastern Feed">HBO Family - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1216" xmltv_id="HBO Family - Pacific Feed">HBO Family - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7102" xmltv_id="HBO Zone HD - East">HBO Zone HD - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/631" xmltv_id="HBO Latino (HBO 7) - Eastern">HBO Latino (HBO 7) - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/632" xmltv_id="Cinemax - Eastern Feed">Cinemax - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1215" xmltv_id="Cinemax - Pacific Feed">Cinemax - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/634" xmltv_id="MoreMax  Eastern">MoreMax  Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1377" xmltv_id="ActionMax - Eastern">ActionMax - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/636" xmltv_id="5 Star Max - Eastern">5 Star Max - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1653" xmltv_id="MovieMax (Max 6) - East">MovieMax (Max 6) - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1652" xmltv_id="ThrillerMax - East">ThrillerMax - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3567" xmltv_id="Cinemax - Eastern HD">Cinemax - Eastern HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/583" xmltv_id="Starz - Eastern">Starz - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1217" xmltv_id="Starz - Pacific">Starz - Pacific</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1194" xmltv_id="Starz Kids &amp; Family - Eastern">Starz Kids &amp; Family - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7088" xmltv_id="Starz Comedy HD">Starz Comedy HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2120" xmltv_id="Starz Edge - Eastern">Starz Edge - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1957" xmltv_id="Starz In Black - Eastern">Starz In Black - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7087" xmltv_id="Starz Cinema HD">Starz Cinema HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/667" xmltv_id="Starz Encore - Eastern">Starz Encore - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1218" xmltv_id="Starz Encore - Pacific">Starz Encore - Pacific</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2080" xmltv_id="Starz Encore Classics - Eastern">Starz Encore Classics - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1959" xmltv_id="Starz Encore Westerns - Eastern">Starz Encore Westerns - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1958" xmltv_id="Starz Encore Suspense - Eastern">Starz Encore Suspense - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4206" xmltv_id="Starz Encore Black - Eastern">Starz Encore Black - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2078" xmltv_id="Starz Encore Action - Eastern">Starz Encore Action - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2128" xmltv_id="Starz Encore Family - Eastern">Starz Encore Family - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/665" xmltv_id="Showtime - Eastern Feed">Showtime - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10734" xmltv_id="Showtime West">Showtime West</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1387" xmltv_id="Showtime 2 - Eastern">Showtime 2 - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2077" xmltv_id="Showtime Showcase - Eastern">Showtime Showcase - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1615" xmltv_id="Showtime Extreme - Eastern">Showtime Extreme - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7106" xmltv_id="Showtime Beyond HD - East">Showtime Beyond HD - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7109" xmltv_id="Showtime Next HD - Eastern">Showtime Next HD - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7112" xmltv_id="Showtime Women HD - Eastern">Showtime Women HD - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/666" xmltv_id="TMC (US) - Eastern Feed">TMC (US) - Eastern Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1222" xmltv_id="TMC (US) - Pacific Feed">TMC (US) - Pacific Feed</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7113" xmltv_id="TMC Xtra HD - Eastern">TMC Xtra HD - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1399" xmltv_id="FLIX - Eastern">FLIX - Eastern</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1848" xmltv_id="SundanceTV USA - East">SundanceTV USA - East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1966" xmltv_id="Independent Film Channel US">Independent Film Channel US</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6214" xmltv_id="Hallmark Movies &amp; Mysteries Eastern - HD">Hallmark Movies &amp; Mysteries Eastern - HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18876" xmltv_id="HDNet Movies HD">HDNet Movies HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6107" xmltv_id="MGM HD (USA)">MGM HD (USA)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2086" xmltv_id="Olympic Channel">Olympic Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6237" xmltv_id="Smithsonian Channel USA HD">Smithsonian Channel USA HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6216" xmltv_id="Crime &amp; Investigation Network USA HD">Crime &amp; Investigation Network USA HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6081" xmltv_id="MTV Live HD">MTV Live HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10170" xmltv_id="Playboy Interactive">Playboy Interactive</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10712" xmltv_id="Playboy HD">Playboy HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/242" xmltv_id="Playboy">Playboy</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10171" xmltv_id="Hustler TV USA On Demand">Hustler TV USA On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14986" xmltv_id="TVG - Television Games Network">TVG - Television Games Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2075" xmltv_id="Sportsman Channel">Sportsman Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1086" xmltv_id="Outdoor Channel US">Outdoor Channel US</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3352" xmltv_id="Fox College Sports - Atlantic">Fox College Sports - Atlantic</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3351" xmltv_id="Fox College Sports - Central">Fox College Sports - Central</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3350" xmltv_id="Fox College Sports - Pacific">Fox College Sports - Pacific</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4499" xmltv_id="Big Ten Network">Big Ten Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8822" xmltv_id="Big Ten Network Overflow 1">Big Ten Network Overflow 1</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8824" xmltv_id="Big Ten Network Overflow 3">Big Ten Network Overflow 3</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8825" xmltv_id="Big Ten Network Overflow 4">Big Ten Network Overflow 4</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/13711" xmltv_id="SEC Network">SEC Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/13759" xmltv_id="SEC Network Alternate">SEC Network Alternate</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1077" xmltv_id="ESPN Classics USA">ESPN Classics USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2114" xmltv_id="Fox Sports 2">Fox Sports 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10853" xmltv_id="beIN Sport USA">beIN Sport USA</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7538" xmltv_id="FOX Soccer Plus">FOX Soccer Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11551" xmltv_id="FOX Soccer Plus HD">FOX Soccer Plus HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/13463" xmltv_id="Eleven Sports">Eleven Sports</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1015" xmltv_id="New England Sports Network">New England Sports Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/14779" xmltv_id="New England Sports Network Plus">New England Sports Network Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4529" xmltv_id="NBC Sports Boston">NBC Sports Boston</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1953" xmltv_id="YES Network">YES Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1649" xmltv_id="MSG (Madison Square Gardens)">MSG (Madison Square Gardens)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1088" xmltv_id="MSG Plus">MSG Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/12612" xmltv_id="MSG - Syracuse">MSG - Syracuse</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/12616" xmltv_id="MSG Plus - Syracuse">MSG Plus - Syracuse</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4186" xmltv_id="SNY: SportsNet New York (Comcast)">SNY: SportsNet New York (Comcast)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4551" xmltv_id="Mid-Atlantic Sports Network">Mid-Atlantic Sports Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7232" xmltv_id="Mid-Atlantic Sports Network 2">Mid-Atlantic Sports Network 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1564" xmltv_id="NBC Sports Washington">NBC Sports Washington</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8742" xmltv_id="NBC Sports Washington Plus">NBC Sports Washington Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1107" xmltv_id="Fox Sports South">Fox Sports South</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4531" xmltv_id="Fox Sports South - Carolinas">Fox Sports South - Carolinas</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8025" xmltv_id="Fox Sports South - TN Nashville">Fox Sports South - TN Nashville</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1352" xmltv_id="Fox Sports Southeast">Fox Sports Southeast</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10127" xmltv_id="Fox Sports Southeast - North Carolina">Fox Sports Southeast - North Carolina</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10131" xmltv_id="Fox Sports Southeast - Tennessee East">Fox Sports Southeast - Tennessee East</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10132" xmltv_id="Fox Sports Southeast - Tennessee">Fox Sports Southeast - Tennessee</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10130" xmltv_id="Fox Sports Southeast - South Carolina">Fox Sports Southeast - South Carolina</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10126" xmltv_id="Fox Sports Southeast - Georgia">Fox Sports Southeast - Georgia</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10128" xmltv_id="Fox Sports Southeast - Tennessee Nashville">Fox Sports Southeast - Tennessee Nashville</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4816" xmltv_id="Fox Sports Sun - Lightening\/Magic">Fox Sports Sun - Lightening\/Magic</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4817" xmltv_id="Fox Sports Sun - Lightening\/Magic HD">Fox Sports Sun - Lightening\/Magic HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31557" xmltv_id="Fox Sports Florida 1">Fox Sports Florida 1</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1114" xmltv_id="Fox Sports Florida">Fox Sports Florida</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31559" xmltv_id="Fox Sports Florida 2">Fox Sports Florida 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31558" xmltv_id="Fox Sports Florida 1 HD">Fox Sports Florida 1 HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1084" xmltv_id="AT&amp;T Sportsnet  Pittsburgh">AT&amp;T Sportsnet  Pittsburgh</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4302" xmltv_id="Fox Sports Ohio - Cleveland">Fox Sports Ohio - Cleveland</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7414" xmltv_id="Fox Sports Ohio - Cleveland HD">Fox Sports Ohio - Cleveland HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11128" xmltv_id="Fox Sports Ohio - Cincinnati (2)">Fox Sports Ohio - Cincinnati (2)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16261" xmltv_id="Fox Sports Ohio - Cincinnati (2) HD">Fox Sports Ohio - Cincinnati (2) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3242" xmltv_id="Sportstime Ohio">Sportstime Ohio</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1115" xmltv_id="Fox Sports Detroit">Fox Sports Detroit</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6020" xmltv_id="Fox Sports Detroit +">Fox Sports Detroit +</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4020" xmltv_id="NBC Sports Chicago">NBC Sports Chicago</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9969" xmltv_id="NBC Sports Chicago Plus">NBC Sports Chicago Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31655" xmltv_id="NBC Sports Chicago Plus 2">NBC Sports Chicago Plus 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1234" xmltv_id="Fox Sports North">Fox Sports North</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6760" xmltv_id="Fox Sports Wisconsin">Fox Sports Wisconsin</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19544" xmltv_id="Fox Sports Midwest - St. Louis">Fox Sports Midwest - St. Louis</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19545" xmltv_id="Fox Sports Midwest - Nebraska">Fox Sports Midwest - Nebraska</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19541" xmltv_id="Fox Sports Midwest - Kansas State">Fox Sports Midwest - Kansas State</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1112" xmltv_id="Fox Sports Indiana">Fox Sports Indiana</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8799" xmltv_id="AT&amp;T Sportsnet Southwest - Houston">AT&amp;T Sportsnet Southwest - Houston</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11576" xmltv_id="Fox Sports Southwest - OK2">Fox Sports Southwest - OK2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31585" xmltv_id="Fox Sports Southwest - OK2 HD Southwest Plus">Fox Sports Southwest - OK2 HD Southwest Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1106" xmltv_id="Fox Sports Southwest">Fox Sports Southwest</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9534" xmltv_id="Fox Sports Southwest - San Antonio">Fox Sports Southwest - San Antonio</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7513" xmltv_id="FOX Sports Southwest - Houston">FOX Sports Southwest - Houston</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/12558" xmltv_id="Fox Sports New Orleans">Fox Sports New Orleans</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10315" xmltv_id="Fox Sports Oklahoma">Fox Sports Oklahoma</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/11516" xmltv_id="Longhorn Network">Longhorn Network</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3342" xmltv_id="Altitude Sports">Altitude Sports</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/5864" xmltv_id="Altitude 2">Altitude 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1108" xmltv_id="AT&amp;T Sportsnet Rocky Mountains">AT&amp;T Sportsnet Rocky Mountains</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10059" xmltv_id="AT&amp;T Sportsnet Rocky Mountain - Utah">AT&amp;T Sportsnet Rocky Mountain - Utah</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1118" xmltv_id="Fox Sports Arizona">Fox Sports Arizona</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31547" xmltv_id="Fox Sports Arizona Plus">Fox Sports Arizona Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4390" xmltv_id="Fox Sports Arizona - N.NM">Fox Sports Arizona - N.NM</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/31944" xmltv_id="Fox Sports Arizona - Alt B.">Fox Sports Arizona - Alt B.</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7283" xmltv_id="Root Sports Northwest">Root Sports Northwest</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4165" xmltv_id="Root Sports Northwest - Seattle">Root Sports Northwest - Seattle</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10852" xmltv_id="Spectrum SportsNet">Spectrum SportsNet</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1105" xmltv_id="Fox Sports West">Fox Sports West</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2592" xmltv_id="Fox Sports West Prime Ticket">Fox Sports West Prime Ticket</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10272" xmltv_id="Fox Sports San Diego">Fox Sports San Diego</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1117" xmltv_id="NBC Sports Bay Area">NBC Sports Bay Area</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9362" xmltv_id="NBC Sports Bay Area\/California Plus">NBC Sports Bay Area\/California Plus</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2836" xmltv_id="NBC Sports California">NBC Sports California</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9363" xmltv_id="NBC Sports Bay Area\/California Plus HD">NBC Sports Bay Area\/California Plus HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6921" xmltv_id="NFL Red Zone">NFL Red Zone</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19983" xmltv_id="DirecTV Sports 701">DirecTV Sports 701</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19985" xmltv_id="DirecTV Sports 702">DirecTV Sports 702</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19987" xmltv_id="DirecTV Sports 703">DirecTV Sports 703</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16849" xmltv_id="DirecTV Sports 704">DirecTV Sports 704</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16852" xmltv_id="DirecTV Sports 705">DirecTV Sports 705</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16853" xmltv_id="DirecTV Sports 706">DirecTV Sports 706</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16856" xmltv_id="DirecTV Sports 707">DirecTV Sports 707</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16857" xmltv_id="DirecTV Sports 708">DirecTV Sports 708</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16859" xmltv_id="DirecTV Sports 709">DirecTV Sports 709</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16862" xmltv_id="DirecTV Sports 710">DirecTV Sports 710</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16863" xmltv_id="DirecTV Sports 711">DirecTV Sports 711</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16866" xmltv_id="DirecTV Sports 712">DirecTV Sports 712</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16867" xmltv_id="DirecTV Sports 713">DirecTV Sports 713</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16869" xmltv_id="DirecTV Sports 714">DirecTV Sports 714</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16871" xmltv_id="DirecTV Sports 715">DirecTV Sports 715</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16873" xmltv_id="DirecTV Sports 716">DirecTV Sports 716</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16875" xmltv_id="DirecTV Sports 717">DirecTV Sports 717</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/16877" xmltv_id="DirecTV Sports 718">DirecTV Sports 718</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/30952" xmltv_id="DirecTV Sports 719">DirecTV Sports 719</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/32374" xmltv_id="DirecTV Sports 720">DirecTV Sports 720</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19280" xmltv_id="DirecTV MLB Extra Innings (721)">DirecTV MLB Extra Innings (721)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19281" xmltv_id="DirecTV MLB Extra Innings HD (721)">DirecTV MLB Extra Innings HD (721)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19283" xmltv_id="DirecTV MLB Extra Innings HD (722)">DirecTV MLB Extra Innings HD (722)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19282" xmltv_id="DirecTV MLB Extra Innings (722)">DirecTV MLB Extra Innings (722)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19284" xmltv_id="DirecTV MLB Extra Innings (723)">DirecTV MLB Extra Innings (723)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19285" xmltv_id="DirecTV MLB Extra Innings HD (723)">DirecTV MLB Extra Innings HD (723)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19286" xmltv_id="DirecTV MLB Extra Innings (724)">DirecTV MLB Extra Innings (724)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19287" xmltv_id="DirecTV MLB Extra Innings HD (724)">DirecTV MLB Extra Innings HD (724)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19288" xmltv_id="DirecTV MLB Extra Innings (725)">DirecTV MLB Extra Innings (725)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19289" xmltv_id="DirecTV MLB Extra Innings HD (725)">DirecTV MLB Extra Innings HD (725)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19290" xmltv_id="DirecTV MLB Extra Innings (726)">DirecTV MLB Extra Innings (726)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19291" xmltv_id="DirecTV MLB Extra Innings HD (726)">DirecTV MLB Extra Innings HD (726)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19293" xmltv_id="DirecTV MLB Extra Innings HD (727)">DirecTV MLB Extra Innings HD (727)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19292" xmltv_id="DirecTV MLB Extra Innings (727)">DirecTV MLB Extra Innings (727)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19294" xmltv_id="DirecTV MLB Extra Innings (728)">DirecTV MLB Extra Innings (728)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19295" xmltv_id="DirecTV MLB Extra Innings HD (728)">DirecTV MLB Extra Innings HD (728)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19296" xmltv_id="DirecTV MLB Extra Innings (729)">DirecTV MLB Extra Innings (729)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19297" xmltv_id="DirecTV MLB Extra Innings HD (729)">DirecTV MLB Extra Innings HD (729)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19299" xmltv_id="DirecTV MLB Extra Innings HD (730)">DirecTV MLB Extra Innings HD (730)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19298" xmltv_id="DirecTV MLB Extra Innings (730)">DirecTV MLB Extra Innings (730)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19301" xmltv_id="DirecTV MLB Extra Innings HD (731)">DirecTV MLB Extra Innings HD (731)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19300" xmltv_id="DirecTV MLB Extra Innings (731)">DirecTV MLB Extra Innings (731)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19303" xmltv_id="DirecTV MLB Extra Innings HD (732)">DirecTV MLB Extra Innings HD (732)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19302" xmltv_id="DirecTV MLB Extra Innings (732)">DirecTV MLB Extra Innings (732)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19305" xmltv_id="DirecTV MLB Extra Innings HD (733)">DirecTV MLB Extra Innings HD (733)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19304" xmltv_id="DirecTV MLB Extra Innings (733)">DirecTV MLB Extra Innings (733)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19306" xmltv_id="DirecTV MLB Extra Innings (734)">DirecTV MLB Extra Innings (734)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19307" xmltv_id="DirecTV MLB Extra Innings HD (734)">DirecTV MLB Extra Innings HD (734)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19309" xmltv_id="DirecTV MLB Extra Innings HD (735)">DirecTV MLB Extra Innings HD (735)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19308" xmltv_id="DirecTV MLB Extra Innings (735)">DirecTV MLB Extra Innings (735)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19311" xmltv_id="DirecTV MLB Extra Innings HD (736)">DirecTV MLB Extra Innings HD (736)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19310" xmltv_id="DirecTV MLB Extra Innings (736)">DirecTV MLB Extra Innings (736)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19312" xmltv_id="DirecTV MLB Extra Innings (737)">DirecTV MLB Extra Innings (737)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19313" xmltv_id="DirecTV MLB Extra Innings HD (737)">DirecTV MLB Extra Innings HD (737)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19314" xmltv_id="DirecTV MLB Extra Innings (738)">DirecTV MLB Extra Innings (738)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19317" xmltv_id="DirecTV MLB Extra Innings HD (739)">DirecTV MLB Extra Innings HD (739)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19316" xmltv_id="DirecTV MLB Extra Innings (739)">DirecTV MLB Extra Innings (739)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19319" xmltv_id="DirecTV MLB Extra Innings HD (740)">DirecTV MLB Extra Innings HD (740)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19318" xmltv_id="DirecTV MLB Extra Innings (740)">DirecTV MLB Extra Innings (740)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19320" xmltv_id="DirecTV MLB Extra Innings (741)">DirecTV MLB Extra Innings (741)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19321" xmltv_id="DirecTV MLB Extra Innings HD (741)">DirecTV MLB Extra Innings HD (741)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19323" xmltv_id="DirecTV MLB Extra Innings (742) HD">DirecTV MLB Extra Innings (742) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19322" xmltv_id="DirecTV MLB Extra Innings (742)">DirecTV MLB Extra Innings (742)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19325" xmltv_id="DirecTV MLB Extra Innings HD (743)">DirecTV MLB Extra Innings HD (743)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19324" xmltv_id="DirecTV MLB Extra Innings (743)">DirecTV MLB Extra Innings (743)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19327" xmltv_id="DirecTV MLB Extra Innings HD (744)">DirecTV MLB Extra Innings HD (744)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19326" xmltv_id="DirecTV MLB Extra Innings (744)">DirecTV MLB Extra Innings (744)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19329" xmltv_id="DirecTV MLB Extra Innings HD (745)">DirecTV MLB Extra Innings HD (745)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19328" xmltv_id="DirecTV MLB Extra Innings (745)">DirecTV MLB Extra Innings (745)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19330" xmltv_id="DirecTV MLB Extra Innings (746)">DirecTV MLB Extra Innings (746)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19331" xmltv_id="DirecTV MLB Extra Innings HD (746)">DirecTV MLB Extra Innings HD (746)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19333" xmltv_id="DirecTV MLB Extra Innings HD (747)">DirecTV MLB Extra Innings HD (747)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19332" xmltv_id="DirecTV MLB Extra Innings (747)">DirecTV MLB Extra Innings (747)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19335" xmltv_id="DirecTV MLB Extra Innings HD (748)">DirecTV MLB Extra Innings HD (748)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19334" xmltv_id="DirecTV MLB Extra Innings (748)">DirecTV MLB Extra Innings (748)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19337" xmltv_id="DirecTV MLB Extra Innings HD (749)">DirecTV MLB Extra Innings HD (749)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19336" xmltv_id="DirecTV MLB Extra Innings (749)">DirecTV MLB Extra Innings (749)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18926" xmltv_id="DirecTV NBA League Pass (750) HD">DirecTV NBA League Pass (750) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18925" xmltv_id="DirecTV NBA League Pass (750)">DirecTV NBA League Pass (750)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18927" xmltv_id="DirecTV NBA League Pass (751)">DirecTV NBA League Pass (751)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18928" xmltv_id="DirecTV NBA League Pass (751) HD">DirecTV NBA League Pass (751) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18929" xmltv_id="DirecTV NBA League Pass (752)">DirecTV NBA League Pass (752)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18930" xmltv_id="DirecTV NBA League Pass (752) HD">DirecTV NBA League Pass (752) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18931" xmltv_id="DirecTV NBA League Pass (753)">DirecTV NBA League Pass (753)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18932" xmltv_id="DirecTV NBA League Pass (753) HD">DirecTV NBA League Pass (753) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18934" xmltv_id="DirecTV NBA League Pass (754) HD">DirecTV NBA League Pass (754) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18933" xmltv_id="DirecTV NBA League Pass (754)">DirecTV NBA League Pass (754)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18936" xmltv_id="DirecTV NBA League Pass (755) HD">DirecTV NBA League Pass (755) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18935" xmltv_id="DirecTV NBA League Pass (755)">DirecTV NBA League Pass (755)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18937" xmltv_id="DirecTV NBA League Pass (756)">DirecTV NBA League Pass (756)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18938" xmltv_id="DirecTV NBA League Pass (756) HD">DirecTV NBA League Pass (756) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18940" xmltv_id="DirecTV NBA League Pass (757) HD">DirecTV NBA League Pass (757) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18939" xmltv_id="DirecTV NBA League Pass (757)">DirecTV NBA League Pass (757)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18942" xmltv_id="DirecTV NBA League Pass (758) HD">DirecTV NBA League Pass (758) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18941" xmltv_id="DirecTV NBA League Pass (758)">DirecTV NBA League Pass (758)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18944" xmltv_id="DirecTV NBA League Pass (759) HD">DirecTV NBA League Pass (759) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18943" xmltv_id="DirecTV NBA League Pass (759)">DirecTV NBA League Pass (759)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18946" xmltv_id="DirecTV NBA League Pass (760) HD">DirecTV NBA League Pass (760) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18945" xmltv_id="DirecTV NBA League Pass (760)">DirecTV NBA League Pass (760)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18948" xmltv_id="DirecTV NBA League Pass (761) HD">DirecTV NBA League Pass (761) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18947" xmltv_id="DirecTV NBA League Pass (761)">DirecTV NBA League Pass (761)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18950" xmltv_id="DirecTV NBA League Pass (762) HD">DirecTV NBA League Pass (762) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18949" xmltv_id="DirecTV NBA League Pass (762)">DirecTV NBA League Pass (762)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18952" xmltv_id="DirecTV NBA League Pass (763) HD">DirecTV NBA League Pass (763) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18951" xmltv_id="DirecTV NBA League Pass (763)">DirecTV NBA League Pass (763)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18954" xmltv_id="DirecTV NBA League Pass (764) HD">DirecTV NBA League Pass (764) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18953" xmltv_id="DirecTV NBA League Pass (764)">DirecTV NBA League Pass (764)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18956" xmltv_id="DirecTV NBA League Pass (765) HD">DirecTV NBA League Pass (765) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18955" xmltv_id="DirecTV NBA League Pass (765)">DirecTV NBA League Pass (765)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18957" xmltv_id="DirecTV NBA League Pass (766)">DirecTV NBA League Pass (766)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18958" xmltv_id="DirecTV NBA League Pass (766) HD">DirecTV NBA League Pass (766) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18960" xmltv_id="DirecTV NBA League Pass (767) HD">DirecTV NBA League Pass (767) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18959" xmltv_id="DirecTV NBA League Pass (767)">DirecTV NBA League Pass (767)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18961" xmltv_id="DirecTV NBA League Pass (768)">DirecTV NBA League Pass (768)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18962" xmltv_id="DirecTV NBA League Pass (768) HD">DirecTV NBA League Pass (768) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18964" xmltv_id="DirecTV NHL Center Ice (769)">DirecTV NHL Center Ice (769)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18963" xmltv_id="DirecTV NHL Center Ice (769) HD">DirecTV NHL Center Ice (769) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18965" xmltv_id="DirecTV NHL Center Ice (770)">DirecTV NHL Center Ice (770)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18966" xmltv_id="DirecTV NHL Center Ice (770) HD">DirecTV NHL Center Ice (770) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18967" xmltv_id="DirecTV NHL Center Ice (771)">DirecTV NHL Center Ice (771)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18968" xmltv_id="DirecTV NHL Center Ice (771) HD">DirecTV NHL Center Ice (771) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18969" xmltv_id="DirecTV NHL Center Ice (772)">DirecTV NHL Center Ice (772)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18970" xmltv_id="DirecTV NHL Center Ice (772) HD">DirecTV NHL Center Ice (772) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18971" xmltv_id="DirecTV NHL Center Ice (773)">DirecTV NHL Center Ice (773)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18972" xmltv_id="DirecTV NHL Center Ice (773) HD">DirecTV NHL Center Ice (773) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18973" xmltv_id="DirecTV NHL Center Ice (774)">DirecTV NHL Center Ice (774)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18974" xmltv_id="DirecTV NHL Center Ice (774) HD">DirecTV NHL Center Ice (774) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18975" xmltv_id="DirecTV NHL Center Ice (775)">DirecTV NHL Center Ice (775)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18976" xmltv_id="DirecTV NHL Center Ice (775) HD">DirecTV NHL Center Ice (775) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18977" xmltv_id="DirecTV NHL Center Ice (776)">DirecTV NHL Center Ice (776)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18978" xmltv_id="DirecTV NHL Center Ice (776) HD">DirecTV NHL Center Ice (776) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18979" xmltv_id="DirecTV NHL Center Ice (777)">DirecTV NHL Center Ice (777)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18980" xmltv_id="DirecTV NHL Center Ice (777) HD">DirecTV NHL Center Ice (777) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18981" xmltv_id="DirecTV NHL Center Ice (778)">DirecTV NHL Center Ice (778)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18982" xmltv_id="DirecTV NHL Center Ice (778) HD">DirecTV NHL Center Ice (778) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18983" xmltv_id="DirecTV NHL Center Ice (779)">DirecTV NHL Center Ice (779)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18984" xmltv_id="DirecTV NHL Center Ice (779) HD">DirecTV NHL Center Ice (779) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18985" xmltv_id="DirecTV NHL Center Ice (780)">DirecTV NHL Center Ice (780)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18986" xmltv_id="DirecTV NHL Center Ice (780) HD">DirecTV NHL Center Ice (780) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18987" xmltv_id="DirecTV NHL Center Ice (781)">DirecTV NHL Center Ice (781)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18988" xmltv_id="DirecTV NHL Center Ice (781) HD">DirecTV NHL Center Ice (781) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18989" xmltv_id="DirecTV NHL Center Ice (782)">DirecTV NHL Center Ice (782)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18990" xmltv_id="DirecTV NHL Center Ice (782) HD">DirecTV NHL Center Ice (782) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18991" xmltv_id="DirecTV NHL Center Ice (783)">DirecTV NHL Center Ice (783)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18992" xmltv_id="DirecTV NHL Center Ice (783) HD">DirecTV NHL Center Ice (783) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18993" xmltv_id="DirecTV NHL Center Ice (784)">DirecTV NHL Center Ice (784)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18994" xmltv_id="DirecTV NHL Center Ice (784) HD">DirecTV NHL Center Ice (784) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18995" xmltv_id="DirecTV NHL Center Ice (785)">DirecTV NHL Center Ice (785)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18996" xmltv_id="DirecTV NHL Center Ice (785) HD">DirecTV NHL Center Ice (785) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18998" xmltv_id="DirecTV NHL Center Ice (786) HD">DirecTV NHL Center Ice (786) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18997" xmltv_id="DirecTV NHL Center Ice (786)">DirecTV NHL Center Ice (786)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/18999" xmltv_id="DirecTV NHL Center Ice (787)">DirecTV NHL Center Ice (787)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/19000" xmltv_id="DirecTV NHL Center Ice (787) HD">DirecTV NHL Center Ice (787) HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9982" xmltv_id="ESPN College Extra 1">ESPN College Extra 1</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15433" xmltv_id="ESPN College Extra 2">ESPN College Extra 2</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15435" xmltv_id="ESPN College Extra 3">ESPN College Extra 3</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15437" xmltv_id="ESPN College Extra 4">ESPN College Extra 4</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15439" xmltv_id="ESPN College Extra 5">ESPN College Extra 5</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15441" xmltv_id="ESPN College Extra 6">ESPN College Extra 6</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15352" xmltv_id="ESPN College Extra 7">ESPN College Extra 7</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15445" xmltv_id="ESPN College Extra 8">ESPN College Extra 8</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15436" xmltv_id="ESPN College Extra 3 HD">ESPN College Extra 3 HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15438" xmltv_id="ESPN College Extra 4 HD">ESPN College Extra 4 HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/15440" xmltv_id="ESPN College Extra 5 HD">ESPN College Extra 5 HD</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4690" xmltv_id="CNN on demand">CNN on demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6665" xmltv_id="ESPN On Demand">ESPN On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6666" xmltv_id="ESPNU On Demand">ESPNU On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4666" xmltv_id="TruTV on Demand">TruTV on Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4781" xmltv_id="Comedy Central on Demand">Comedy Central on Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4782" xmltv_id="Discovery Channel (US) on demand">Discovery Channel (US) on demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/5260" xmltv_id="Disney on Demand">Disney on Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6796" xmltv_id="Boomerang On Demand">Boomerang On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7945" xmltv_id="Nickelodeon USA On Demand">Nickelodeon USA On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6669" xmltv_id="Freeform On Demand">Freeform On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/7948" xmltv_id="CMT US On Demand">CMT US On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4788" xmltv_id="Fuse On Demand">Fuse On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6667" xmltv_id="ESPN Deportes On Demand">ESPN Deportes On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3479" xmltv_id="HBO On Demand">HBO On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4657" xmltv_id="Cinemax on Demand">Cinemax on Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3476" xmltv_id="Starz On Demand">Starz On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6199" xmltv_id="Starz Encore on Demand">Starz Encore on Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4658" xmltv_id="Showtime on Demand">Showtime on Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4659" xmltv_id="TMC on Demand">TMC on Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9340" xmltv_id="HDNet Movies On Dmenad">HDNet Movies On Dmenad</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3630" xmltv_id="Playboy On Demand">Playboy On Demand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6848" xmltv_id="Big Ten Network OnDemand">Big Ten Network OnDemand</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10671" xmltv_id="CGTN (CCTV4)">CGTN (CCTV4)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/4216" xmltv_id="CCTV-4 America">CCTV-4 America</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/9604" xmltv_id="TFC - The Filipino Channel">TFC - The Filipino Channel</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/6954" xmltv_id="GMA\/Pinoy TV">GMA\/Pinoy TV</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/2937" xmltv_id="SBTN (Saigon Broadcasting Television Network)">SBTN (Saigon Broadcasting Television Network)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8675" xmltv_id="SBS (Korean)">SBS (Korean)</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/10575" xmltv_id="Arirang TV">Arirang TV</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/8671" xmltv_id="TV Globo">TV Globo</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/3257" xmltv_id="RTVi">RTVi</channel>
+    <channel update="i" site="tvtv.us" site_id="36212D/1561" xmltv_id="MHz Worldview">MHz Worldview</channel>
+  </channels>
+</site>

--- a/siteini.pack/USA/tvtv.us.ini
+++ b/siteini.pack/USA/tvtv.us.ini
@@ -1,0 +1,97 @@
+﻿**------------------------------------------------------------------------------------------------
+* @header_start
+* WebGrab+Plus ini for grabbing EPG data from TvGuide websites
+* @Site: tvtv.us
+* @MinSWversion: V1.1.1/55.26
+*   none
+* @Revision 1 - [07/09/2018] r00ty
+*   Initial work on tvtv.us (and tvtv.ca separately) 
+* @Remarks:
+*   mostly json and on single page
+* @header_end
+**------------------------------------------------------------------------------------------------
+site {url=tvtv.us|timezone=UTC|maxdays=7|cultureinfo=en-US|charset=ISO-8859-1|episodesystem=onscreen|ratingsystem=US}
+*
+** Separate lineup and station ID
+index_temp_1.modify{set|'config_site_id'}
+index_temp_2.modify{set|'config_site_id'}
+index_temp_1.modify{remove(type=regex)|(\/.*)}
+index_temp_2.modify{remove(type=regex)|(.*\/).*}
+url_index{url|https://tvtv.us/tvm/t/tv/v4/lineups/XLINEUPIDX/listings/grid?detail=%27full%27&start=|urldate|T00:00Z&end=|urldate|T23:59Z&station=XSTATIONIDX}
+**
+** Adjust url to insert site ID and station ID
+url_index.modify{replace|XLINEUPIDX|'index_temp_1'}
+url_index.modify{replace|XSTATIONIDX|'index_temp_2'}
+
+url_index.headers {customheader=Accept-Encoding=gzip,deflate} * to speedup the downloading of the index pages
+urldate.format {datestring|yyyy-MM-dd}
+**
+url_index.headers {accept=application/json, text/javascript, */*}
+**
+index_showsplit.scrub {regex||"listings"\:\[\s*(\{.*?"showHost".*?\},?\s*)+.*?\].*||}
+**
+index_variable_element.modify {set|'config_site_id'}
+global_temp_3.scrub {regex||\{\s*"channel":\{.*?"logoFilename":"(.*?)"\,?.*?"listings".*]||}
+index_urlchannellogo.modify {addstart|https://tvtv.us/tvm/i/image/station/100x100/'global_temp_3'}
+**
+scope.range{(indexshowdetails)|end}
+index_start.scrub {single|"listDateTime"|:"|",|",}
+index_duration.scrub {single|"duration"|:|,}
+index_duration.modify {calculate(format=time)|60 /}
+index_description.scrub {single|"description"|:"|",|",}
+index_title.scrub {single|"showName"|:"|",|",}
+index_subtitle.scrub {single|"episodeTitle"|:"|",|",}
+index_category.scrub {single|"showType"|:"|",|",,}
+index_rating.scrub {single|"rating"|:"|",|",}
+**
+** Some special handling for sports
+index_temp_3.scrub {single|"team1"|:"|",|",}
+index_temp_4.scrub {single|"team2"|:"|",|",}
+index_temp_5.scrub {single|"location"|:"|",|",}
+index_temp_6.scrub {single|"league"|:"|",|",}
+** Show ID only for secondary lookup per show
+index_temp_7.scrub {single|"showID"|:|,}
+index_temp_8.modify {addstart('index_temp_3' not "")|'index_temp_3'}
+index_temp_8.modify {addend('index_temp_8' not "")| vs. 'index_temp_4'.}
+index_description.modify {addstart('index_temp_6' not "")|'index_temp_6' }
+index_description.modify {addend('index_temp_8' not "")| 'index_temp_8'}
+index_description.modify {addend('index_temp_5' not "")| 'index_temp_5'}
+index_subtitle.modify {addstart('index_subtitle' "")|'index_temp_8'}
+**
+** Split multiple categories
+index_category.modify {replace|,|\|}
+end_scope
+**
+** If you would like episode numbers, then uncomment the following lines. It will mean an extra web action per show (much slower)
+*index_urlshow.modify {addstart|https://tvtv.us/tvm/t/tv/v4/episodes/'index_temp_7'}
+*scope.range{(showdetails)|end}
+*title.scrub{single|"seriesName"|:"|",|",}
+*temp_1.scrub {single|"seasonNumber"|:|,}
+*temp_2.scrub {single('temp_1' not "")|"seasonSeqNo"|:|,}
+*temp_1.modify {replace|0|}
+*temp_2.modify {replace|0|}
+*episode.modify {addstart('temp_2' not "")|S'temp_1'E'temp_2'}
+*end_scope
+** End of episode number section
+**
+**  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
+**      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
+**
+** Note, the 36212D is the line-up for New York DirecTV. You can get your own lineup by visiting http://tvtv.us enter your location.
+** It should then load a URL like: https://tvtv.us/ny/new-york/lu36212D for which you just take everything after "lu" as your lineup ID
+** Then you can add a line like the following (replacing the site_id value with your own linup:
+**     <channel update="i" site="tvtv.us" site_id="36212D" xmltv_id="tvtv New York">tvtv New York</channel>
+** It will then generate a channel file for your line-up
+*index_temp_1.modify{set|'config_site_id'}
+*index_temp_1.modify{remove(type=regex)|(\/.*)}
+*url_index{url|https://tvtv.us/tvm/t/tv/v4/lineups/XLINEUPIDX}
+*url_index.modify{replace|XLINEUPIDX|'index_temp_1'}
+*index_temp_9.scrub{regex||"lineupID":"(.*?)"||}
+*index_site_channel.scrub {regex||\{.*?"stations":\[(?:\s*{.*?"name"\:"(.*?)",.*?\},?)+.*\]||}
+*index_site_id.scrub {regex||\{.*?"stations":\[(?:\s*{.*?"stationID"\:(.*?),.*?\},?)+.*\]||}
+*index_site_channel.modify {replace|\'|}
+*index_site_id.modify {addstart|'index_temp_9'/}
+*scope.range {(channellist)|end}
+*index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}
+*end_scope
+** @auto_xml_channel_end


### PR DESCRIPTION
Added new ini and channels for tvtv.us, by default only uses index. Optional show lookup just for episode info. It's much faster without, so it's optional.