### PR TITLE
Update for Lithuania sites

### DIFF
--- a/siteini.pack/Lithuania/cgates.lt.channels.xml
+++ b/siteini.pack/Lithuania/cgates.lt.channels.xml
@@ -1,124 +1,226 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version 1.54.6/0.01 -- Jan van Straaten" site="cgates.lt">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V2.1 -- Jan van Straaten" site="cgates.lt">
   <channels>
-    <channel update="i" site="cgates.lt" site_id="3" xmltv_id="LRT (LTV) Televizija">LRT (LTV) Televizija</channel>
-    <channel update="i" site="cgates.lt" site_id="2" xmltv_id="TV3">TV3</channel>
-    <channel update="i" site="cgates.lt" site_id="1" xmltv_id="LNK">LNK</channel>
-    <channel update="i" site="cgates.lt" site_id="5" xmltv_id="Baltijos TV">Baltijos TV</channel>
-    <channel update="i" site="cgates.lt" site_id="7" xmltv_id="Lietuvos ryto TV">Lietuvos ryto TV</channel>
-    <channel update="i" site="cgates.lt" site_id="9" xmltv_id="LRT Kultūra">LRT Kultūra</channel>
-    <channel update="i" site="cgates.lt" site_id="6" xmltv_id="TV6">TV6</channel>
-    <channel update="i" site="cgates.lt" site_id="8" xmltv_id="TV1">TV1</channel>
-    <channel update="i" site="cgates.lt" site_id="79" xmltv_id="Balticum TV">Balticum TV</channel>
-    <channel update="i" site="cgates.lt" site_id="11" xmltv_id="Info TV">Info TV</channel>
-    <channel update="i" site="cgates.lt" site_id="88" xmltv_id="TV8">TV8</channel>
-    <channel update="i" site="cgates.lt" site_id="83" xmltv_id="Marijampolės TV">Marijampolės TV</channel>
-    <channel update="i" site="cgates.lt" site_id="98" xmltv_id="Dzūkijos TV">Dzūkijos TV</channel>
-    <channel update="i" site="cgates.lt" site_id="86" xmltv_id="Pūkas TV">Pūkas TV</channel>
-    <channel update="i" site="cgates.lt" site_id="75" xmltv_id="Seimas tiesiogiai">Seimas tiesiogiai</channel>
-    <channel update="i" site="cgates.lt" site_id="155" xmltv_id="Šiaulių televizija">Šiaulių televizija</channel>
-    <channel update="i" site="cgates.lt" site_id="156" xmltv_id="Gerų naujienų televizija">Gerų naujienų televizija</channel>
-    <channel update="i" site="cgates.lt" site_id="157" xmltv_id="TV7">TV7</channel>
-    <channel update="i" site="cgates.lt" site_id="13" xmltv_id="Pervyj Baltijskij Kanal">Pervyj Baltijskij Kanal</channel>
-    <channel update="i" site="cgates.lt" site_id="4" xmltv_id="RTR Planeta">RTR Planeta</channel>
-    <channel update="i" site="cgates.lt" site_id="14" xmltv_id="NTV Mir">NTV Mir</channel>
-    <channel update="i" site="cgates.lt" site_id="15" xmltv_id="REN TV Lietuva">REN TV Lietuva</channel>
-    <channel update="i" site="cgates.lt" site_id="130" xmltv_id="STS">STS</channel>
-    <channel update="i" site="cgates.lt" site_id="18" xmltv_id="Animal Planet">Animal Planet</channel>
-    <channel update="i" site="cgates.lt" site_id="19" xmltv_id="National Geographic Channel">National Geographic Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="17" xmltv_id="Discovery Channel">Discovery Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="21" xmltv_id="Discovery World">Discovery World</channel>
-    <channel update="i" site="cgates.lt" site_id="20" xmltv_id="Discovery Science">Discovery Science</channel>
-    <channel update="i" site="cgates.lt" site_id="94" xmltv_id="Discovery TLC">Discovery TLC</channel>
-    <channel update="i" site="cgates.lt" site_id="102" xmltv_id="Investigation Discovery">Investigation Discovery</channel>
-    <channel update="i" site="cgates.lt" site_id="23" xmltv_id="Zdorovoje Televidenije">Zdorovoje Televidenije</channel>
-    <channel update="i" site="cgates.lt" site_id="33" xmltv_id="Nase Liubimoje Kino">Nase Liubimoje Kino</channel>
-    <channel update="i" site="cgates.lt" site_id="35" xmltv_id="FOX">FOX</channel>
-    <channel update="i" site="cgates.lt" site_id="32" xmltv_id="Teleklub">Teleklub</channel>
-    <channel update="i" site="cgates.lt" site_id="91" xmltv_id="Balticum Auksinis">Balticum Auksinis</channel>
-    <channel update="i" site="cgates.lt" site_id="92" xmltv_id="Sony Entertainment Television">Sony Entertainment Television</channel>
-    <channel update="i" site="cgates.lt" site_id="158" xmltv_id="Sony Turbo">Sony Turbo</channel>
-    <channel update="i" site="cgates.lt" site_id="159" xmltv_id="FilmZone">FilmZone</channel>
-    <channel update="i" site="cgates.lt" site_id="160" xmltv_id="FilmZone+">FilmZone+</channel>
-    <channel update="i" site="cgates.lt" site_id="38" xmltv_id="Sport 1">Sport 1</channel>
-    <channel update="i" site="cgates.lt" site_id="36" xmltv_id="Eurosport">Eurosport</channel>
-    <channel update="i" site="cgates.lt" site_id="37" xmltv_id="Eurosport 2">Eurosport 2</channel>
-    <channel update="i" site="cgates.lt" site_id="39" xmltv_id="MTV Europe">MTV Europe</channel>
-    <channel update="i" site="cgates.lt" site_id="40" xmltv_id="VH1">VH1</channel>
-    <channel update="i" site="cgates.lt" site_id="41" xmltv_id="Mezzo">Mezzo</channel>
-    <channel update="i" site="cgates.lt" site_id="10" xmltv_id="Liuks! TV">Liuks! TV</channel>
-    <channel update="i" site="cgates.lt" site_id="161" xmltv_id="Žvaigždė.TV">Žvaigždė.TV</channel>
-    <channel update="i" site="cgates.lt" site_id="43" xmltv_id="Nickelodeon">Nickelodeon</channel>
-    <channel update="i" site="cgates.lt" site_id="44" xmltv_id="Cartoon Network">Cartoon Network</channel>
-    <channel update="i" site="cgates.lt" site_id="45" xmltv_id="Detskij Mir">Detskij Mir</channel>
-    <channel update="i" site="cgates.lt" site_id="46" xmltv_id="Boomerang">Boomerang</channel>
-    <channel update="i" site="cgates.lt" site_id="100" xmltv_id="Pingviniukas">Pingviniukas</channel>
-    <channel update="i" site="cgates.lt" site_id="57" xmltv_id="Blue Hustler">Blue Hustler</channel>
-    <channel update="i" site="cgates.lt" site_id="55" xmltv_id="CNN International">CNN International</channel>
-    <channel update="i" site="cgates.lt" site_id="56" xmltv_id="BBC World News">BBC World News</channel>
-    <channel update="i" site="cgates.lt" site_id="74" xmltv_id="Bloomberg Television">Bloomberg Television</channel>
-    <channel update="i" site="cgates.lt" site_id="165" xmltv_id="Euronews">Euronews</channel>
-    <channel update="i" site="cgates.lt" site_id="76" xmltv_id="Tele 5">Tele 5</channel>
-    <channel update="i" site="cgates.lt" site_id="49" xmltv_id="TVP Polonia">TVP Polonia</channel>
-    <channel update="i" site="cgates.lt" site_id="162" xmltv_id="Ukraine 24">Ukraine 24</channel>
-    <channel update="i" site="cgates.lt" site_id="73" xmltv_id="Belarus 24">Belarus 24</channel>
-    <channel update="i" site="cgates.lt" site_id="54" xmltv_id="RTL">RTL</channel>
-    <channel update="i" site="cgates.lt" site_id="51" xmltv_id="Deutsche Welle">Deutsche Welle</channel>
-    <channel update="i" site="cgates.lt" site_id="50" xmltv_id="TV5 Europe">TV5 Europe</channel>
-    <channel update="i" site="cgates.lt" site_id="87" xmltv_id="France 24">France 24</channel>
-    <channel update="i" site="cgates.lt" site_id="163" xmltv_id="CNBC Europe">CNBC Europe</channel>
-    <channel update="i" site="cgates.lt" site_id="164" xmltv_id="Arirang TV">Arirang TV</channel>
-    <channel update="i" site="cgates.lt" site_id="101" xmltv_id="Fashion TV">Fashion TV</channel>
-    <channel update="i" site="cgates.lt" site_id="140" xmltv_id="LRT HD">LRT HD</channel>
-    <channel update="i" site="cgates.lt" site_id="150" xmltv_id="Pūkas TV HD">Pūkas TV HD</channel>
-    <channel update="i" site="cgates.lt" site_id="105" xmltv_id="Luxe.TV HD">Luxe.TV HD</channel>
-    <channel update="i" site="cgates.lt" site_id="106" xmltv_id="Fuel TV HD">Fuel TV HD</channel>
-    <channel update="i" site="cgates.lt" site_id="147" xmltv_id="Sport 1 HD">Sport 1 HD</channel>
-    <channel update="i" site="cgates.lt" site_id="141" xmltv_id="MTV Live HD">MTV Live HD</channel>
-    <channel update="i" site="cgates.lt" site_id="136" xmltv_id="HD1 Movie Channel">HD1 Movie Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="137" xmltv_id="Travel Channel HD">Travel Channel HD</channel>
-    <channel update="i" site="cgates.lt" site_id="138" xmltv_id="iConcerts HD">iConcerts HD</channel>
-    <channel update="i" site="cgates.lt" site_id="107" xmltv_id="AutoPlus">AutoPlus</channel>
-    <channel update="i" site="cgates.lt" site_id="109" xmltv_id="Motors TV">Motors TV</channel>
-    <channel update="i" site="cgates.lt" site_id="110" xmltv_id="Extreme Sports">Extreme Sports</channel>
-    <channel update="i" site="cgates.lt" site_id="111" xmltv_id="Russkij Extreme">Russkij Extreme</channel>
-    <channel update="i" site="cgates.lt" site_id="112" xmltv_id="Boets">Boets</channel>
-    <channel update="i" site="cgates.lt" site_id="85" xmltv_id="Playboy TV">Playboy TV</channel>
-    <channel update="i" site="cgates.lt" site_id="113" xmltv_id="Telekafe">Telekafe</channel>
-    <channel update="i" site="cgates.lt" site_id="114" xmltv_id="Fine Living">Fine Living</channel>
-    <channel update="i" site="cgates.lt" site_id="116" xmltv_id="TDK">TDK</channel>
-    <channel update="i" site="cgates.lt" site_id="117" xmltv_id="Kuhnya TV">Kuhnya TV</channel>
-    <channel update="i" site="cgates.lt" site_id="118" xmltv_id="Food Network">Food Network</channel>
-    <channel update="i" site="cgates.lt" site_id="78" xmltv_id="Travel Channel">Travel Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="24" xmltv_id="The History Channel">The History Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="108" xmltv_id="Okhota i Rybalka">Okhota i Rybalka</channel>
-    <channel update="i" site="cgates.lt" site_id="119" xmltv_id="Viasat Explore">Viasat Explore</channel>
-    <channel update="i" site="cgates.lt" site_id="120" xmltv_id="Viasat History">Viasat History</channel>
-    <channel update="i" site="cgates.lt" site_id="121" xmltv_id="Viasat Nature">Viasat Nature</channel>
-    <channel update="i" site="cgates.lt" site_id="122" xmltv_id="CBS Reality">CBS Reality</channel>
-    <channel update="i" site="cgates.lt" site_id="123" xmltv_id="Moya Planeta">Moya Planeta</channel>
-    <channel update="i" site="cgates.lt" site_id="125" xmltv_id="K1 Movie Channel">K1 Movie Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="126" xmltv_id="AMC">AMC</channel>
-    <channel update="i" site="cgates.lt" site_id="127" xmltv_id="Illusion +">Illusion +</channel>
-    <channel update="i" site="cgates.lt" site_id="85" xmltv_id="Playboy TV">Playboy TV</channel>
-    <channel update="i" site="cgates.lt" site_id="93" xmltv_id="Dom Kino">Dom Kino</channel>
-    <channel update="i" site="cgates.lt" site_id="16" xmltv_id="RTV International">RTV International</channel>
-    <channel update="i" site="cgates.lt" site_id="31" xmltv_id="TV XXI">TV XXI</channel>
-    <channel update="i" site="cgates.lt" site_id="128" xmltv_id="K2 Movie Channel">K2 Movie Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="131" xmltv_id="Russkij Illusion">Russkij Illusion</channel>
-    <channel update="i" site="cgates.lt" site_id="85" xmltv_id="Playboy TV">Playboy TV</channel>
-    <channel update="i" site="cgates.lt" site_id="132" xmltv_id="Disney Channel">Disney Channel</channel>
-    <channel update="i" site="cgates.lt" site_id="133" xmltv_id="Disney XD">Disney XD</channel>
-    <channel update="i" site="cgates.lt" site_id="134" xmltv_id="Disney Junior">Disney Junior</channel>
-    <channel update="i" site="cgates.lt" site_id="135" xmltv_id="Da Vinci Learning">Da Vinci Learning</channel>
-    <channel update="i" site="cgates.lt" site_id="139" xmltv_id="Baby TV">Baby TV</channel>
-    <channel update="i" site="cgates.lt" site_id="151" xmltv_id="KidZone TV">KidZone TV</channel>
-    <channel update="i" site="cgates.lt" site_id="27" xmltv_id="TV 1000">TV 1000</channel>
-    <channel update="i" site="cgates.lt" site_id="28" xmltv_id="TV 1000 Russkoje Kino">TV 1000 Russkoje Kino</channel>
-    <channel update="i" site="cgates.lt" site_id="96" xmltv_id="TV 1000 Action">TV 1000 Action</channel>
-    <channel update="i" site="cgates.lt" site_id="97" xmltv_id="TV 1000 Premium">TV 1000 Premium</channel>
-    <channel update="i" site="cgates.lt" site_id="68" xmltv_id="Viasat Sport Baltic">Viasat Sport Baltic</channel>
-    <channel update="i" site="cgates.lt" site_id="69" xmltv_id="Viasat Golf">Viasat Golf</channel>
-    <channel update="i" site="cgates.lt" site_id="99" xmltv_id="Viasat Motor">Viasat Motor</channel>
+    <channel update="i" site="cgates.lt" site_id="lrt-televizija-hd" xmltv_id="LRT Televizija HD">LRT Televizija HD</channel>
+    <channel update="i" site="cgates.lt" site_id="lrt-kultura-hd" xmltv_id="LRT Kultūra HD">LRT Kultūra HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tv3-hd" xmltv_id="TV3 HD">TV3 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tv6-hd" xmltv_id="TV6 HD">TV6 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tv8-hd" xmltv_id="TV8 HD">TV8 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="lietuvos-ryto-tv-hd" xmltv_id="Lietuvos ryto TV HD">Lietuvos ryto TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="lnk" xmltv_id="LNK">LNK</channel>
+    <channel update="i" site="cgates.lt" site_id="btv" xmltv_id="BTV">BTV</channel>
+    <channel update="i" site="cgates.lt" site_id="tv1" xmltv_id="TV1">TV1</channel>
+    <channel update="i" site="cgates.lt" site_id="balticum-tv" xmltv_id="Balticum TV">Balticum TV</channel>
+    <channel update="i" site="cgates.lt" site_id="info-tv" xmltv_id="Info TV">Info TV</channel>
+    <channel update="i" site="cgates.lt" site_id="marijampoles-tv" xmltv_id="Marijampolės TV">Marijampolės TV</channel>
+    <channel update="i" site="cgates.lt" site_id="dzukijos-tv" xmltv_id="Dzūkijos TV">Dzūkijos TV</channel>
+    <channel update="i" site="cgates.lt" site_id="seimas-tiesiogiai" xmltv_id="Seimas tiesiogiai">Seimas tiesiogiai</channel>
+    <channel update="i" site="cgates.lt" site_id="siauliu-televizija" xmltv_id="Šiaulių televizija">Šiaulių televizija</channel>
+    <channel update="i" site="cgates.lt" site_id="pukas-tv-hd" xmltv_id="Pūkas TV HD">Pūkas TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="geru-naujienu-televizija" xmltv_id="Gerų naujienų televizija">Gerų naujienų televizija</channel>
+    <channel update="i" site="cgates.lt" site_id="tv7" xmltv_id="TV7">TV7</channel>
+    <channel update="i" site="cgates.lt" site_id="liuks-tv" xmltv_id="Liuks! TV">Liuks! TV</channel>
+    <channel update="i" site="cgates.lt" site_id="lrt-lituanica" xmltv_id="LRT Lituanica">LRT Lituanica</channel>
+    <channel update="i" site="cgates.lt" site_id="pervyj-baltijskij-kanal" xmltv_id="Pervyj Baltijskij Kanal">Pervyj Baltijskij Kanal</channel>
+    <channel update="i" site="cgates.lt" site_id="ntv-mir" xmltv_id="NTV Mir">NTV Mir</channel>
+    <channel update="i" site="cgates.lt" site_id="nastojashcheje-vremya" xmltv_id="Nastojashcheje Vremya">Nastojashcheje Vremya</channel>
+    <channel update="i" site="cgates.lt" site_id="rtv-international" xmltv_id="RTV International">RTV International</channel>
+    <channel update="i" site="cgates.lt" site_id="ren-tv-lietuva" xmltv_id="Ren TV Lietuva">Ren TV Lietuva</channel>
+    <channel update="i" site="cgates.lt" site_id="fox" xmltv_id="FOX">FOX</channel>
+    <channel update="i" site="cgates.lt" site_id="fox-life" xmltv_id="FOX Life">FOX Life</channel>
+    <channel update="i" site="cgates.lt" site_id="balticum-auksinis" xmltv_id="Balticum Auksinis">Balticum Auksinis</channel>
+    <channel update="i" site="cgates.lt" site_id="sony-channel-hd" xmltv_id="Sony Channel HD">Sony Channel HD</channel>
+    <channel update="i" site="cgates.lt" site_id="balticum-platinum-hd" xmltv_id="Balticum Platinum HD">Balticum Platinum HD</channel>
+    <channel update="i" site="cgates.lt" site_id="vip-comedy" xmltv_id="ViP Comedy">ViP Comedy</channel>
+    <channel update="i" site="cgates.lt" site_id="tnt-comedy" xmltv_id="TNT Comedy">TNT Comedy</channel>
+    <channel update="i" site="cgates.lt" site_id="dom-kino" xmltv_id="Dom Kino">Dom Kino</channel>
+    <channel update="i" site="cgates.lt" site_id="sony-turbo-hd" xmltv_id="Sony Turbo HD">Sony Turbo HD</channel>
+    <channel update="i" site="cgates.lt" site_id="discovery-channel" xmltv_id="Discovery Channel">Discovery Channel</channel>
+    <channel update="i" site="cgates.lt" site_id="animal-planet-hd" xmltv_id="Animal Planet HD">Animal Planet HD</channel>
+    <channel update="i" site="cgates.lt" site_id="national-geographic-channel" xmltv_id="National Geographic Channel">National Geographic Channel</channel>
+    <channel update="i" site="cgates.lt" site_id="id-xtra-hd" xmltv_id="Investigation Discovery HD">Investigation Discovery HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tlc" xmltv_id="TLC">TLC</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-history" xmltv_id="Viasat History">Viasat History</channel>
+    <channel update="i" site="cgates.lt" site_id="discovery-showcase-hd" xmltv_id="Discovery Showcase HD">Discovery Showcase HD</channel>
+    <channel update="i" site="cgates.lt" site_id="travel-channel-hd" xmltv_id="Travel Channel HD">Travel Channel HD</channel>
+    <channel update="i" site="cgates.lt" site_id="food-network" xmltv_id="Food Network">Food Network</channel>
+    <channel update="i" site="cgates.lt" site_id="sport-1-hd" xmltv_id="Sport 1 HD">Sport 1 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="eurosport-1-hd" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="eurosport-2-hd" xmltv_id="Eurosport 2 HD">Eurosport 2 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="fuel-tv-hd" xmltv_id="Fuel TV HD">Fuel TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="mtv-hits" xmltv_id="MTV Hits">MTV Hits</channel>
+    <channel update="i" site="cgates.lt" site_id="vh1" xmltv_id="VH1">VH1</channel>
+    <channel update="i" site="cgates.lt" site_id="mtv-live-hd" xmltv_id="MTV Live HD">MTV Live HD</channel>
+    <channel update="i" site="cgates.lt" site_id="mezzo" xmltv_id="Mezzo">Mezzo</channel>
+    <channel update="i" site="cgates.lt" site_id="zvaigzde-tv" xmltv_id="Žvaigždė.TV">Žvaigždė.TV</channel>
+    <channel update="i" site="cgates.lt" site_id="fashion-tv" xmltv_id="Fashion TV">Fashion TV</channel>
+    <channel update="i" site="cgates.lt" site_id="luxe-tv-hd" xmltv_id="Luxe.TV HD">Luxe.TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="fine-living" xmltv_id="Fine Living">Fine Living</channel>
+    <channel update="i" site="cgates.lt" site_id="blue-hustler" xmltv_id="Blue Hustler">Blue Hustler</channel>
+    <channel update="i" site="cgates.lt" site_id="kidzone-plus-hd" xmltv_id="KidZone Plus HD">KidZone Plus HD</channel>
+    <channel update="i" site="cgates.lt" site_id="cartoon-network" xmltv_id="Cartoon Network">Cartoon Network</channel>
+    <channel update="i" site="cgates.lt" site_id="nick-jr" xmltv_id="Nick Jr.">Nick Jr.</channel>
+    <channel update="i" site="cgates.lt" site_id="nick-toons" xmltv_id="Nick Toons">Nick Toons</channel>
+    <channel update="i" site="cgates.lt" site_id="smartzone-hd" xmltv_id="Smartzone HD">Smartzone HD</channel>
+    <channel update="i" site="cgates.lt" site_id="nickelodeon" xmltv_id="Nickelodeon">Nickelodeon</channel>
+    <channel update="i" site="cgates.lt" site_id="kidzone-tv" xmltv_id="KidZone TV">KidZone TV</channel>
+    <channel update="i" site="cgates.lt" site_id="boomerang" xmltv_id="Boomerang">Boomerang</channel>
+    <channel update="i" site="cgates.lt" site_id="cnn-international" xmltv_id="CNN International">CNN International</channel>
+    <channel update="i" site="cgates.lt" site_id="bbc-world-news" xmltv_id="BBC World News">BBC World News</channel>
+    <channel update="i" site="cgates.lt" site_id="euronews" xmltv_id="Euronews">Euronews</channel>
+    <channel update="i" site="cgates.lt" site_id="euronews-2" xmltv_id="Euronews RU">Euronews RU</channel>
+    <channel update="i" site="cgates.lt" site_id="bloomberg-television" xmltv_id="Bloomberg Television">Bloomberg Television</channel>
+    <channel update="i" site="cgates.lt" site_id="tvp-polonia" xmltv_id="TVP Polonia">TVP Polonia</channel>
+    <channel update="i" site="cgates.lt" site_id="tvp-info" xmltv_id="TVP Info">TVP Info</channel>
+    <channel update="i" site="cgates.lt" site_id="rtl" xmltv_id="RTL">RTL</channel>
+    <channel update="i" site="cgates.lt" site_id="france-24" xmltv_id="France 24">France 24</channel>
+    <channel update="i" site="cgates.lt" site_id="deutsche-welle" xmltv_id="Deutsche Welle">Deutsche Welle</channel>
+    <channel update="i" site="cgates.lt" site_id="cnbc-europe" xmltv_id="CNBC Europe">CNBC Europe</channel>
+    <channel update="i" site="cgates.lt" site_id="arirang-tv" xmltv_id="Arirang TV">Arirang TV</channel>
+    <channel update="i" site="cgates.lt" site_id="belarus-24" xmltv_id="Belarus 24">Belarus 24</channel>
+    <channel update="i" site="cgates.lt" site_id="ukraine-24" xmltv_id="Ukraine 24">Ukraine 24</channel>
+    <channel update="i" site="cgates.lt" site_id="lrt-televizija-hd" xmltv_id="LRT Televizija HD">LRT Televizija HD</channel>
+    <channel update="i" site="cgates.lt" site_id="lrt-kultura-hd" xmltv_id="LRT Kultūra HD">LRT Kultūra HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tv3-hd" xmltv_id="TV3 HD">TV3 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tv6-hd" xmltv_id="TV6 HD">TV6 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tv8-hd" xmltv_id="TV8 HD">TV8 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="lietuvos-ryto-tv-hd" xmltv_id="Lietuvos ryto TV HD">Lietuvos ryto TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="lnk" xmltv_id="LNK">LNK</channel>
+    <channel update="i" site="cgates.lt" site_id="btv" xmltv_id="BTV">BTV</channel>
+    <channel update="i" site="cgates.lt" site_id="tv1" xmltv_id="TV1">TV1</channel>
+    <channel update="i" site="cgates.lt" site_id="balticum-tv" xmltv_id="Balticum TV">Balticum TV</channel>
+    <channel update="i" site="cgates.lt" site_id="info-tv" xmltv_id="Info TV">Info TV</channel>
+    <channel update="i" site="cgates.lt" site_id="marijampoles-tv" xmltv_id="Marijampolės TV">Marijampolės TV</channel>
+    <channel update="i" site="cgates.lt" site_id="dzukijos-tv" xmltv_id="Dzūkijos TV">Dzūkijos TV</channel>
+    <channel update="i" site="cgates.lt" site_id="seimas-tiesiogiai" xmltv_id="Seimas tiesiogiai">Seimas tiesiogiai</channel>
+    <channel update="i" site="cgates.lt" site_id="siauliu-televizija" xmltv_id="Šiaulių televizija">Šiaulių televizija</channel>
+    <channel update="i" site="cgates.lt" site_id="pukas-tv-hd" xmltv_id="Pūkas TV HD">Pūkas TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="geru-naujienu-televizija" xmltv_id="Gerų naujienų televizija">Gerų naujienų televizija</channel>
+    <channel update="i" site="cgates.lt" site_id="tv7" xmltv_id="TV7">TV7</channel>
+    <channel update="i" site="cgates.lt" site_id="liuks-tv" xmltv_id="Liuks! TV">Liuks! TV</channel>
+    <channel update="i" site="cgates.lt" site_id="lrt-lituanica" xmltv_id="LRT Lituanica">LRT Lituanica</channel>
+    <channel update="i" site="cgates.lt" site_id="fox-life" xmltv_id="FOX Life">FOX Life</channel>
+    <channel update="i" site="cgates.lt" site_id="balticum-auksinis" xmltv_id="Balticum Auksinis">Balticum Auksinis</channel>
+    <channel update="i" site="cgates.lt" site_id="sony-channel-hd" xmltv_id="Sony Channel HD">Sony Channel HD</channel>
+    <channel update="i" site="cgates.lt" site_id="balticum-platinum-hd" xmltv_id="Balticum Platinum HD">Balticum Platinum HD</channel>
+    <channel update="i" site="cgates.lt" site_id="vip-comedy" xmltv_id="ViP Comedy">ViP Comedy</channel>
+    <channel update="i" site="cgates.lt" site_id="fox-hd" xmltv_id="FOX HD">FOX HD</channel>
+    <channel update="i" site="cgates.lt" site_id="sony-turbo-hd" xmltv_id="Sony Turbo HD">Sony Turbo HD</channel>
+    <channel update="i" site="cgates.lt" site_id="filmzone-hd" xmltv_id="FilmZone+ HD">FilmZone+ HD</channel>
+    <channel update="i" site="cgates.lt" site_id="filmzone" xmltv_id="FilmZone">FilmZone</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-xxi" xmltv_id="TV XXI">TV XXI</channel>
+    <channel update="i" site="cgates.lt" site_id="hd1-movie-channel" xmltv_id="HD1 Movie Channel">HD1 Movie Channel</channel>
+    <channel update="i" site="cgates.lt" site_id="k1-movie-channel" xmltv_id="K1 Movie Channel">K1 Movie Channel</channel>
+    <channel update="i" site="cgates.lt" site_id="k2-movie-channel" xmltv_id="K2 Movie Channel">K2 Movie Channel</channel>
+    <channel update="i" site="cgates.lt" site_id="amc" xmltv_id="AMC">AMC</channel>
+    <channel update="i" site="cgates.lt" site_id="illusion" xmltv_id="Illusion +">Illusion +</channel>
+    <channel update="i" site="cgates.lt" site_id="russkij-illusion" xmltv_id="Russkij Illusion">Russkij Illusion</channel>
+    <channel update="i" site="cgates.lt" site_id="eurochannel" xmltv_id="Eurochannel">Eurochannel</channel>
+    <channel update="i" site="cgates.lt" site_id="okhota-i-rybalka" xmltv_id="Okhota i Rybalka">Okhota i Rybalka</channel>
+    <channel update="i" site="cgates.lt" site_id="discovery-channel" xmltv_id="Discovery Channel">Discovery Channel</channel>
+    <channel update="i" site="cgates.lt" site_id="nat-geo-wild" xmltv_id="Nat Geo Wild">Nat Geo Wild</channel>
+    <channel update="i" site="cgates.lt" site_id="animal-planet-hd" xmltv_id="Animal Planet HD">Animal Planet HD</channel>
+    <channel update="i" site="cgates.lt" site_id="id-xtra-hd" xmltv_id="Investigation Discovery HD">Investigation Discovery HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tlc" xmltv_id="TLC">TLC</channel>
+    <channel update="i" site="cgates.lt" site_id="discovery-science-hd" xmltv_id="Discovery Science HD">Discovery Science HD</channel>
+    <channel update="i" site="cgates.lt" site_id="national-geographic-hd" xmltv_id="National Geographic HD">National Geographic HD</channel>
+    <channel update="i" site="cgates.lt" site_id="cbs-reality" xmltv_id="CBS Reality">CBS Reality</channel>
+    <channel update="i" site="cgates.lt" site_id="dtx-hd" xmltv_id="DTX HD">DTX HD</channel>
+    <channel update="i" site="cgates.lt" site_id="history-channel-hd" xmltv_id="History Channel HD">History Channel HD</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-explore" xmltv_id="Viasat Explore">Viasat Explore</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-history" xmltv_id="Viasat History">Viasat History</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-nature" xmltv_id="Viasat Nature">Viasat Nature</channel>
+    <channel update="i" site="cgates.lt" site_id="discovery-showcase-hd" xmltv_id="Discovery Showcase HD">Discovery Showcase HD</channel>
+    <channel update="i" site="cgates.lt" site_id="sport-1-hd" xmltv_id="Sport 1 HD">Sport 1 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="eurosport-1-hd" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="eurosport-2-hd" xmltv_id="Eurosport 2 HD">Eurosport 2 HD</channel>
+    <channel update="i" site="cgates.lt" site_id="fuel-tv-hd" xmltv_id="Fuel TV HD">Fuel TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="setanta-sports-hd" xmltv_id="Setanta Sports HD">Setanta Sports HD</channel>
+    <channel update="i" site="cgates.lt" site_id="fight-sports-hd" xmltv_id="Fight Sports HD">Fight Sports HD</channel>
+    <channel update="i" site="cgates.lt" site_id="autoplus" xmltv_id="AutoPlus">AutoPlus</channel>
+    <channel update="i" site="cgates.lt" site_id="motorsport-tv" xmltv_id="Motorsport.tv">Motorsport.tv</channel>
+    <channel update="i" site="cgates.lt" site_id="extreme-sports" xmltv_id="Extreme Sports">Extreme Sports</channel>
+    <channel update="i" site="cgates.lt" site_id="mtv-hits" xmltv_id="MTV Hits">MTV Hits</channel>
+    <channel update="i" site="cgates.lt" site_id="vh1" xmltv_id="VH1">VH1</channel>
+    <channel update="i" site="cgates.lt" site_id="mtv-live-hd" xmltv_id="MTV Live HD">MTV Live HD</channel>
+    <channel update="i" site="cgates.lt" site_id="mezzo" xmltv_id="Mezzo">Mezzo</channel>
+    <channel update="i" site="cgates.lt" site_id="zvaigzde-tv" xmltv_id="Žvaigždė.TV">Žvaigždė.TV</channel>
+    <channel update="i" site="cgates.lt" site_id="fashion-tv" xmltv_id="Fashion TV">Fashion TV</channel>
+    <channel update="i" site="cgates.lt" site_id="luxe-tv-hd" xmltv_id="Luxe.TV HD">Luxe.TV HD</channel>
+    <channel update="i" site="cgates.lt" site_id="fine-living" xmltv_id="Fine Living">Fine Living</channel>
+    <channel update="i" site="cgates.lt" site_id="iconcerts-hd" xmltv_id="iConcerts HD">iConcerts HD</channel>
+    <channel update="i" site="cgates.lt" site_id="travel-channel-hd" xmltv_id="Travel Channel HD">Travel Channel HD</channel>
+    <channel update="i" site="cgates.lt" site_id="food-network" xmltv_id="Food Network">Food Network</channel>
+    <channel update="i" site="cgates.lt" site_id="kuhnya-tv" xmltv_id="Kuhnya TV">Kuhnya TV</channel>
+    <channel update="i" site="cgates.lt" site_id="domashniy" xmltv_id="Domashniy">Domashniy</channel>
+    <channel update="i" site="cgates.lt" site_id="mir-tv" xmltv_id="Mir TV">Mir TV</channel>
+    <channel update="i" site="cgates.lt" site_id="sts" xmltv_id="STS">STS</channel>
+    <channel update="i" site="cgates.lt" site_id="peretz-international" xmltv_id="Peretz International">Peretz International</channel>
+    <channel update="i" site="cgates.lt" site_id="blue-hustler" xmltv_id="Blue Hustler">Blue Hustler</channel>
+    <channel update="i" site="cgates.lt" site_id="playboy-tv" xmltv_id="Playboy TV">Playboy TV</channel>
+    <channel update="i" site="cgates.lt" site_id="kidzone-plus-hd" xmltv_id="KidZone Plus HD">KidZone Plus HD</channel>
+    <channel update="i" site="cgates.lt" site_id="cartoon-network" xmltv_id="Cartoon Network">Cartoon Network</channel>
+    <channel update="i" site="cgates.lt" site_id="disney-channel" xmltv_id="Disney Channel">Disney Channel</channel>
+    <channel update="i" site="cgates.lt" site_id="disney-xd" xmltv_id="Disney XD">Disney XD</channel>
+    <channel update="i" site="cgates.lt" site_id="disney-junior" xmltv_id="Disney Junior">Disney Junior</channel>
+    <channel update="i" site="cgates.lt" site_id="baby-tv" xmltv_id="Baby TV">Baby TV</channel>
+    <channel update="i" site="cgates.lt" site_id="da-vinci-learning" xmltv_id="Da Vinci Learning">Da Vinci Learning</channel>
+    <channel update="i" site="cgates.lt" site_id="jim-jam" xmltv_id="Jim Jam">Jim Jam</channel>
+    <channel update="i" site="cgates.lt" site_id="nick-jr" xmltv_id="Nick Jr.">Nick Jr.</channel>
+    <channel update="i" site="cgates.lt" site_id="nick-toons" xmltv_id="Nick Toons">Nick Toons</channel>
+    <channel update="i" site="cgates.lt" site_id="smartzone-hd" xmltv_id="Smartzone HD">Smartzone HD</channel>
+    <channel update="i" site="cgates.lt" site_id="nickelodeon" xmltv_id="Nickelodeon">Nickelodeon</channel>
+    <channel update="i" site="cgates.lt" site_id="kidzone-tv" xmltv_id="KidZone TV">KidZone TV</channel>
+    <channel update="i" site="cgates.lt" site_id="boomerang" xmltv_id="Boomerang">Boomerang</channel>
+    <channel update="i" site="cgates.lt" site_id="tvc-international" xmltv_id="TVC International">TVC International</channel>
+    <channel update="i" site="cgates.lt" site_id="nauka" xmltv_id="Nauka">Nauka</channel>
+    <channel update="i" site="cgates.lt" site_id="moya-planeta" xmltv_id="Moya Planeta">Moya Planeta</channel>
+    <channel update="i" site="cgates.lt" site_id="doktor" xmltv_id="Doktor">Doktor</channel>
+    <channel update="i" site="cgates.lt" site_id="sarafan" xmltv_id="Sarafan">Sarafan</channel>
+    <channel update="i" site="cgates.lt" site_id="tdk" xmltv_id="TDK">TDK</channel>
+    <channel update="i" site="cgates.lt" site_id="mult" xmltv_id="Mult">Mult</channel>
+    <channel update="i" site="cgates.lt" site_id="khl" xmltv_id="KHL">KHL</channel>
+    <channel update="i" site="cgates.lt" site_id="futbol" xmltv_id="Futbol">Futbol</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000" xmltv_id="TV 1000">TV 1000</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000-russkoje-kino" xmltv_id="TV 1000 Russkoje Kino">TV 1000 Russkoje Kino</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000-action" xmltv_id="TV 1000 Action">TV 1000 Action</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000-premium" xmltv_id="TV 1000 Premium">TV 1000 Premium</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-sport-baltic" xmltv_id="TVPlay Sports">TVPlay Sports</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-sport-baltic-hd" xmltv_id="TVPlay Sports HD">TVPlay Sports HD</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-sport-baltic" xmltv_id="TVPlay Sports">TVPlay Sports</channel>
+    <channel update="i" site="cgates.lt" site_id="viasat-sport-baltic-hd" xmltv_id="TVPlay Sports HD">TVPlay Sports HD</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000" xmltv_id="TV 1000">TV 1000</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000-russkoje-kino" xmltv_id="TV 1000 Russkoje Kino">TV 1000 Russkoje Kino</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000-action" xmltv_id="TV 1000 Action">TV 1000 Action</channel>
+    <channel update="i" site="cgates.lt" site_id="tv-1000-premium" xmltv_id="TV 1000 Premium">TV 1000 Premium</channel>
+    <channel update="i" site="cgates.lt" site_id="ntv-mir" xmltv_id="NTV Mir">NTV Mir</channel>
+    <channel update="i" site="cgates.lt" site_id="vremya" xmltv_id="Vremya">Vremya</channel>
+    <channel update="i" site="cgates.lt" site_id="telekafe" xmltv_id="Telekafe">Telekafe</channel>
+    <channel update="i" site="cgates.lt" site_id="muzyka-pervogo" xmltv_id="Muzyka Pervogo">Muzyka Pervogo</channel>
+    <channel update="i" site="cgates.lt" site_id="dom-kino" xmltv_id="Dom Kino">Dom Kino</channel>
+    <channel update="i" site="cgates.lt" site_id="dom-kino-premium-hd" xmltv_id="Dom Kino Premium HD">Dom Kino Premium HD</channel>
+    <channel update="i" site="cgates.lt" site_id="karusel" xmltv_id="Karusel">Karusel</channel>
+    <channel update="i" site="cgates.lt" site_id="bobior" xmltv_id="Bobior">Bobior</channel>
+    <channel update="i" site="cgates.lt" site_id="o" xmltv_id="O!">O!</channel>
+    <channel update="i" site="cgates.lt" site_id="pojehali" xmltv_id="Pojehali!">Pojehali!</channel>
+    <channel update="i" site="cgates.lt" site_id="ntv-stil" xmltv_id="NTV Stil">NTV Stil</channel>
+    <channel update="i" site="cgates.lt" site_id="ntv-serial" xmltv_id="NTV Serial">NTV Serial</channel>
+    <channel update="i" site="cgates.lt" site_id="ntv-pravo" xmltv_id="NTV Pravo">NTV Pravo</channel>
+    <channel update="i" site="cgates.lt" site_id="nastojashcheje-vremya" xmltv_id="Nastojashcheje Vremya">Nastojashcheje Vremya</channel>
+    <channel update="i" site="cgates.lt" site_id="rtv-international" xmltv_id="RTV International">RTV International</channel>
+    <channel update="i" site="cgates.lt" site_id="cnn-international" xmltv_id="CNN International">CNN International</channel>
+    <channel update="i" site="cgates.lt" site_id="bbc-world-news" xmltv_id="BBC World News">BBC World News</channel>
+    <channel update="i" site="cgates.lt" site_id="euronews" xmltv_id="Euronews">Euronews</channel>
+    <channel update="i" site="cgates.lt" site_id="euronews-2" xmltv_id="Euronews RU">Euronews RU</channel>
+    <channel update="i" site="cgates.lt" site_id="bloomberg-television" xmltv_id="Bloomberg Television">Bloomberg Television</channel>
+    <channel update="i" site="cgates.lt" site_id="tvp-polonia" xmltv_id="TVP Polonia">TVP Polonia</channel>
+    <channel update="i" site="cgates.lt" site_id="tvp-info" xmltv_id="TVP Info">TVP Info</channel>
+    <channel update="i" site="cgates.lt" site_id="rtl" xmltv_id="RTL">RTL</channel>
+    <channel update="i" site="cgates.lt" site_id="france-24" xmltv_id="France 24">France 24</channel>
+    <channel update="i" site="cgates.lt" site_id="deutsche-welle" xmltv_id="Deutsche Welle">Deutsche Welle</channel>
+    <channel update="i" site="cgates.lt" site_id="cnbc-europe" xmltv_id="CNBC Europe">CNBC Europe</channel>
+    <channel update="i" site="cgates.lt" site_id="arirang-tv" xmltv_id="Arirang TV">Arirang TV</channel>
+    <channel update="i" site="cgates.lt" site_id="belarus-24" xmltv_id="Belarus 24">Belarus 24</channel>
+    <channel update="i" site="cgates.lt" site_id="ukraine-24" xmltv_id="Ukraine 24">Ukraine 24</channel>
   </channels>
 </site>

--- a/siteini.pack/Lithuania/cgates.lt.ini
+++ b/siteini.pack/Lithuania/cgates.lt.ini
@@ -3,6 +3,8 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: cgates.lt
 * @MinSWversion: V1.1.1/54
+* @Revision 1 - [10/09/2018] Erikas Rudinskas
+*   - rewrote everything, since page completelly changed.
 * @Revision 0 - [01/09/2015] Karolis Vaikutis
 *   - creation
 * @Remarks:
@@ -10,39 +12,23 @@
 * @header_end
 **------------------------------------------------------------------------------------------------
 
-site {url=cgates.lt|timezone=Europe/Vilnius|maxdays=6.3|cultureinfo=lt-LT|charset=UTF-8|titlematchfactor=90}
-url_index{url|http://www.cgates.lt/lt/televizija/tv-programa-savaitei/id/|channel|/day/|urldate}
-urldate.format {datestring|yyyy-MM-dd}
-
-index_showsplit.scrub {multi|<div class="program_col">|<a|</a>|                                </div>}
-
-index_start.scrub {single|<span class="date_start">|| </span>|                        <span class="program_title">}
-*index_title.scrub {single|<span class="program_title">||(|</a><br>}
-index_title.scrub {regex||<span class="program_title">\s*([^\<\(]*)||}
-index_titleoriginal.scrub {single(lang=xx)|<span class="program_title">|(|)|</a><br>}
-index_productiondate.scrub {single(seperator="," include=last)|<span class="program_title">||</span>|</a><br>}
-index_category.scrub {multi(separator="," include="Komedija""Trileris""Veiksm""Drama""Briograf""Misti""Siaubo""Kriminial""Nuotyk""Istor""Miuzikl""Animac""Dokument""Šeim""Fanta""Muzikin""Romant""Moksl""Karinis""Vestern")|<span class="program_title">|)|</span>|</a><br>}
-
-index_urlshow {url||href="||"|rel="nofollow">}
-
-*detail_title.scrub {single|$('.right h1').html(|'|(|);}
-detail_title.scrub {regex||\$\('.right h1'\).html\('\s*([^\'\(]*)||}
-detail_description.scrub {single|<span class="d_t">pradžia</span>|   <div>|</div>|<div style="margin:10px 0;">}
-detail_description.modify {addend|. }
-detail_description.modify {cleanup}
-detail_showicon.scrub {url||<div class="program_det">|<img src="|"|/>}
-
-detail_title.modify {remove(type=regex)|^\s*}
-detail_title.modify {remove(type=regex)|\s*$}
+site {url=cgates.lt|timezone=Europe/Vilnius|maxdays=5|cultureinfo=lt-LT|charset=UTF-8|titlematchfactor=90|episodesystem=onscreen|allowlastpageoverflow}
+url_index {url|https://www.cgates.lt/tv-kanalai/|channel|/}
+index_showsplit.scrub {multi|<table class="tv_programa">\n<tbody>|<tr|</tr>|</tbody>\n</table>}
+*
+index_start.scrub {single|<td class="laikas">||</td>|}
+index_title.scrub {single|<div class="vc_toggle_title">||<br />|}
+index_description.scrub {single|<div class="vc_toggle_content">|<p>|</p>|</div>}
+*
+index_title.modify {replace(type=regex)| \(.+\),.+||}
 
 **------------------------------------------------------------------------------------------------
 **      #####  CHANNEL FILE CREATION (only to create the cgates.lt.channel.xml file)
 ** @auto_xml_channel_start
-
 *scope.range {(channellist)|end}
 *url_index {url|http://www.cgates.lt/lt/televizija/tv-programa-savaitei}
-*index_site_channel.scrub {multi|http://www.cgates.lt/mimages/TVPrograms/items/|alt="|"|>}
-*index_site_id.scrub {multi|http://www.cgates.lt/mimages/TVPrograms/items/||/list_image|>}
+*index_site_channel.scrub {multi|<span class="tooltip-c"> <h6 >||</h6>|>}
+*index_site_id.scrub {multi|<a href="https://www.cgates.lt/tv-kanalai/||/" target="_self" class="shortcode-tooltip|}
 *end_scope
 ** @auto_xml_channel_end
 **------------------------------------------------------------------------------------------------

--- a/siteini.pack/Lithuania/tv.viasat.lt.channels.xml
+++ b/siteini.pack/Lithuania/tv.viasat.lt.channels.xml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V2.1 -- Jan van Straaten" site="viasat.lt">
+  <channels>
+    <channel update="i" site="viasat.lt" site_id="303" xmltv_id="TV3">TV3</channel>
+    <channel update="i" site="viasat.lt" site_id="304" xmltv_id="TV6">TV6</channel>
+    <channel update="i" site="viasat.lt" site_id="545" xmltv_id="TV8">TV8</channel>
+    <channel update="i" site="viasat.lt" site_id="306" xmltv_id="LRT Televizija">LRT Televizija</channel>
+    <channel update="i" site="viasat.lt" site_id="325" xmltv_id="LRT Lituanica">LRT Lituanica</channel>
+    <channel update="i" site="viasat.lt" site_id="301" xmltv_id="LNK">LNK</channel>
+    <channel update="i" site="viasat.lt" site_id="318" xmltv_id="Lietuvos ryto televizija">Lietuvos ryto televizija</channel>
+    <channel update="i" site="viasat.lt" site_id="305" xmltv_id="BTV">BTV</channel>
+    <channel update="i" site="viasat.lt" site_id="302" xmltv_id="TV1">TV1</channel>
+    <channel update="i" site="viasat.lt" site_id="975" xmltv_id="TV1000 Premium">TV1000 Premium</channel>
+    <channel update="i" site="viasat.lt" site_id="977" xmltv_id="TV1000">TV1000</channel>
+    <channel update="i" site="viasat.lt" site_id="976" xmltv_id="TV1000 Action">TV1000 Action</channel>
+    <channel update="i" site="viasat.lt" site_id="978" xmltv_id="TV1000 Kino">TV1000 Kino</channel>
+    <channel update="i" site="viasat.lt" site_id="919" xmltv_id="TVPlay Sports">TVPlay Sports</channel>
+    <channel update="i" site="viasat.lt" site_id="972" xmltv_id="Viasat Explore Nordic">Viasat Explore Nordic</channel>
+    <channel update="i" site="viasat.lt" site_id="973" xmltv_id="Viasat History">Viasat History</channel>
+    <channel update="i" site="viasat.lt" site_id="958" xmltv_id="VIASAT Nature East">VIASAT Nature East</channel>
+    <channel update="i" site="viasat.lt" site_id="242" xmltv_id="Epic Drama">Epic Drama</channel>
+    <channel update="i" site="viasat.lt" site_id="49" xmltv_id="Nat Geo Wild Europe">Nat Geo Wild Europe</channel>
+    <channel update="i" site="viasat.lt" site_id="936" xmltv_id="National Geographic Channel HD">National Geographic Channel HD</channel>
+    <channel update="i" site="viasat.lt" site_id="145" xmltv_id="Охота и рыбалка">Охота и рыбалка</channel>
+    <channel update="i" site="viasat.lt" site_id="583" xmltv_id=" Kidzone Baltic"> Kidzone Baltic</channel>
+    <channel update="i" site="viasat.lt" site_id="905" xmltv_id="Disney Channel">Disney Channel</channel>
+    <channel update="i" site="viasat.lt" site_id="907" xmltv_id="Disney XD">Disney XD</channel>
+    <channel update="i" site="viasat.lt" site_id="906" xmltv_id="Disney Junior">Disney Junior</channel>
+    <channel update="i" site="viasat.lt" site_id="560" xmltv_id="Nick Jr.">Nick Jr.</channel>
+    <channel update="i" site="viasat.lt" site_id="960" xmltv_id="Nickelodeon EURO">Nickelodeon EURO</channel>
+    <channel update="i" site="viasat.lt" site_id="649" xmltv_id="Nicktoon">Nicktoon</channel>
+    <channel update="i" site="viasat.lt" site_id="208" xmltv_id="PBK">PBK</channel>
+    <channel update="i" site="viasat.lt" site_id="546" xmltv_id="СТС Балтия">СТС Балтия</channel>
+    <channel update="i" site="viasat.lt" site_id="106" xmltv_id="НТВ-Мир">НТВ-Мир</channel>
+    <channel update="i" site="viasat.lt" site_id="199" xmltv_id="RenTV Baltic">RenTV Baltic</channel>
+    <channel update="i" site="viasat.lt" site_id="100" xmltv_id="E! Entertainment">E! Entertainment</channel>
+    <channel update="i" site="viasat.lt" site_id="69" xmltv_id="MTV Hits">MTV Hits</channel>
+    <channel update="i" site="viasat.lt" site_id="68" xmltv_id="VH1 Euro IMM">VH1 Euro IMM</channel>
+    <channel update="i" site="viasat.lt" site_id="985" xmltv_id="Playboy TV Europe">Playboy TV Europe</channel>
+    <channel update="i" site="viasat.lt" site_id="78" xmltv_id="CNN">CNN</channel>
+    <channel update="i" site="viasat.lt" site_id="80" xmltv_id="BBC World">BBC World</channel>
+    <channel update="i" site="viasat.lt" site_id="532" xmltv_id="NHK World">NHK World</channel>
+    <channel update="i" site="viasat.lt" site_id="412" xmltv_id="RT">RT</channel>
+  </channels>
+</site>

--- a/siteini.pack/Lithuania/tv.viasat.lt.ini
+++ b/siteini.pack/Lithuania/tv.viasat.lt.ini
@@ -1,0 +1,32 @@
+**------------------------------------------------------------------------------------------------
+* @header_start
+* WebGrab+Plus ini for grabbing EPG data from TvGuide websites
+* @Site: viasat.lt
+* @MinSWversion: V1.1.1/53
+* @Revision 0 - [10/09/2018] Erikas Rudinskas
+*   - creation
+* @Remarks:
+*   none
+* @header_end
+**------------------------------------------------------------------------------------------------
+
+site {url=viasat.lt|timezone=Europe/Vilnius|maxdays=7|cultureinfo=lt-LT|charset=UTF-8|titlematchfactor=90}
+url_index {url|https://tv.viasat.lt/channel/|channel|/?d=|urldate|}
+urldate.format {daycounter|0}
+*
+index_showsplit.scrub {multi|<div class="cprograms half wrapper">|<div class="program-info|            </div>|<div id="rightcol">}
+*
+index_start.scrub {single|<span class="time">||</span>|}
+index_title.scrub {single|<h2>|>|</a>|</h2>}
+index_description.scrub {single|<div style="float:left; width:380px; margin-right:10px;" >||</div>|}
+index_showicon.scrub {single|<img style="width:165px;" src="||"/>|}
+**  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
+**      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
+**
+** @auto_xml_channel_start
+*scope.range {(channellist)|end}
+*url_index {url|https://tv.viasat.lt}
+*index_site_channel.scrub {regex||<div class="channelName">[\s\n]+<a href="https://tv.viasat.lt/channel/\d+/">([^\n]+)</a>||}
+*index_site_id.scrub {regex||<div class="channelName">[\s\n]+<a href="https://tv.viasat.lt/channel/(\d+)/">||}
+*end_scope
+** @auto_xml_channel_end

--- a/siteini.pack/Lithuania/tv24.lt.channels.xml
+++ b/siteini.pack/Lithuania/tv24.lt.channels.xml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.1.5 -- Jan van Straaten" site="tv24.lt">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V2.1 -- Jan van Straaten" site="tv24.lt">
   <channels>
     <channel update="i" site="tv24.lt" site_id="lrt-televizija" xmltv_id="LRT Televizija">LRT Televizija</channel>
-    <channel update="i" site="tv24.lt" site_id="tv3-4" xmltv_id="TV3">TV3</channel>
+    <channel update="i" site="tv24.lt" site_id="tv3-2" xmltv_id="TV3">TV3</channel>
     <channel update="i" site="tv24.lt" site_id="lnk" xmltv_id="LNK">LNK</channel>
     <channel update="i" site="tv24.lt" site_id="btv" xmltv_id="BTV">BTV</channel>
     <channel update="i" site="tv24.lt" site_id="lrt-kultura" xmltv_id="LRT Kultūra">LRT Kultūra</channel>
@@ -24,7 +24,7 @@
     <channel update="i" site="tv24.lt" site_id="marijampoles-tv" xmltv_id="Marijampolės TV">Marijampolės TV</channel>
     <channel update="i" site="tv24.lt" site_id="siauliu-tv" xmltv_id="Šiaulių TV">Šiaulių TV</channel>
     <channel update="i" site="tv24.lt" site_id="zvaigzde" xmltv_id="Žvaigždė">Žvaigždė</channel>
-    <channel update="i" site="tv24.lt" site_id="penki-tv" xmltv_id="Penki TV">Penki TV</channel>
+    <channel update="i" site="tv24.lt" site_id="taurages-tvk" xmltv_id="Tauragės TVK">Tauragės TVK</channel>
     <channel update="i" site="tv24.lt" site_id="seimas-tiesiogiai" xmltv_id="Seimas tiesiogiai">Seimas tiesiogiai</channel>
     <channel update="i" site="tv24.lt" site_id="init-ekstra-tv" xmltv_id="Init Ekstra TV">Init Ekstra TV</channel>
     <channel update="i" site="tv24.lt" site_id="play-tv" xmltv_id="Play TV">Play TV</channel>
@@ -43,7 +43,7 @@
     <channel update="i" site="tv24.lt" site_id="filmbox-baltic" xmltv_id="Filmbox Baltic">Filmbox Baltic</channel>
     <channel update="i" site="tv24.lt" site_id="mgm-hd" xmltv_id="MGM HD">MGM HD</channel>
     <channel update="i" site="tv24.lt" site_id="amc" xmltv_id="AMC">AMC</channel>
-    <channel update="i" site="tv24.lt" site_id="viasat-sport-baltic" xmltv_id="Viasat Sport Baltic">Viasat Sport Baltic</channel>
+    <channel update="i" site="tv24.lt" site_id="tvplay-sports" xmltv_id="TVPlay Sports">TVPlay Sports</channel>
     <channel update="i" site="tv24.lt" site_id="viasat-os-4" xmltv_id="Viasat OS 4">Viasat OS 4</channel>
     <channel update="i" site="tv24.lt" site_id="eurosport-1" xmltv_id="Eurosport 1">Eurosport 1</channel>
     <channel update="i" site="tv24.lt" site_id="eurosport-2-bundesliga" xmltv_id="Eurosport 2 (Bundesliga)">Eurosport 2 (Bundesliga)</channel>
@@ -111,7 +111,7 @@
     <channel update="i" site="tv24.lt" site_id="bbc-world" xmltv_id="BBC World">BBC World</channel>
     <channel update="i" site="tv24.lt" site_id="cnn" xmltv_id="CNN">CNN</channel>
     <channel update="i" site="tv24.lt" site_id="euronews" xmltv_id="Euronews">Euronews</channel>
-    <channel update="i" site="tv24.lt" site_id="tv3-3" xmltv_id="TV3+">TV3+</channel>
+    <channel update="i" site="tv24.lt" site_id="3-1" xmltv_id="3+">3+</channel>
     <channel update="i" site="tv24.lt" site_id="sky-news" xmltv_id="Sky News">Sky News</channel>
     <channel update="i" site="tv24.lt" site_id="france-24-uk" xmltv_id="France 24 UK">France 24 UK</channel>
     <channel update="i" site="tv24.lt" site_id="da-vinci-learning" xmltv_id="Da Vinci Learning">Da Vinci Learning</channel>

--- a/siteini.pack/Lithuania/tvprograma.lt.channels.xml
+++ b/siteini.pack/Lithuania/tvprograma.lt.channels.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version 1.1.1/55.27 -- Jan van Straaten" site="tvprograma.lt">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version  V2.1 -- Jan van Straaten" site="tvprograma.lt">
   <channels>
     <channel update="i" site="tvprograma.lt" site_id="lrt-televizija/30" xmltv_id="LRT TELEVIZIJA">LRT TELEVIZIJA</channel>
     <channel update="i" site="tvprograma.lt" site_id="lnk/3" xmltv_id="LNK">LNK</channel>
@@ -16,6 +16,7 @@
     <channel update="i" site="tvprograma.lt" site_id="discovery/35" xmltv_id="Discovery">Discovery</channel>
     <channel update="i" site="tvprograma.lt" site_id="info-tv/40" xmltv_id="INFO TV">INFO TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="liuks/146" xmltv_id="Liuks!">Liuks!</channel>
+    <channel update="i" site="tvprograma.lt" site_id="tvplay-sports/353" xmltv_id="TVPlay Sports">TVPlay Sports</channel>
     <channel update="i" site="tvprograma.lt" site_id="lrt-hd/317" xmltv_id="LRT HD">LRT HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="sport1/24" xmltv_id="Sport1">Sport1</channel>
     <channel update="i" site="tvprograma.lt" site_id="eurosport/33" xmltv_id="EUROSPORT">EUROSPORT</channel>
@@ -24,21 +25,22 @@
     <channel update="i" site="tvprograma.lt" site_id="extreme-sports/119" xmltv_id="Extreme Sports">Extreme Sports</channel>
     <channel update="i" site="tvprograma.lt" site_id="ntvsport/58" xmltv_id="NTV+Sport">NTV+Sport</channel>
     <channel update="i" site="tvprograma.lt" site_id="nba-tv/260" xmltv_id="NBA TV">NBA TV</channel>
-    <channel update="i" site="tvprograma.lt" site_id="motors-tv/89" xmltv_id="Motors TV">Motors TV</channel>
+    <channel update="i" site="tvprograma.lt" site_id="motorsport-tv/89" xmltv_id="Motorsport TV">Motorsport TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="viasat-golf/29" xmltv_id="Viasat Golf">Viasat Golf</channel>
     <channel update="i" site="tvprograma.lt" site_id="viasat-golf-hd/280" xmltv_id="Viasat Golf HD">Viasat Golf HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="viasat-hockey/154" xmltv_id="Viasat Hockey">Viasat Hockey</channel>
     <channel update="i" site="tvprograma.lt" site_id="viasat-sport/278" xmltv_id="Viasat Sport">Viasat Sport</channel>
     <channel update="i" site="tvprograma.lt" site_id="viasat-sport-hd/279" xmltv_id="Viasat Sport HD">Viasat Sport HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="russkij-extreme/208" xmltv_id="Russkij Extreme">Russkij Extreme</channel>
-    <channel update="i" site="tvprograma.lt" site_id="viasat-motor/273" xmltv_id="Viasat Motor">Viasat Motor</channel>
-    <channel update="i" site="tvprograma.lt" site_id="viasat-motor-hd/274" xmltv_id="Viasat Motor HD">Viasat Motor HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="boec/63" xmltv_id="Boec">Boec</channel>
     <channel update="i" site="tvprograma.lt" site_id="auto-plius/103" xmltv_id="Auto Plius">Auto Plius</channel>
     <channel update="i" site="tvprograma.lt" site_id="tvp-sport/195" xmltv_id="TVP Sport">TVP Sport</channel>
     <channel update="i" site="tvprograma.lt" site_id="khl-tv/207" xmltv_id="KHL TV">KHL TV</channel>
+    <channel update="i" site="tvprograma.lt" site_id="setanta-sports/330" xmltv_id="Setanta Sports">Setanta Sports</channel>
     <channel update="i" site="tvprograma.lt" site_id="fuel-tv/313" xmltv_id="Fuel TV">Fuel TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="discovery-turbo-xtra/323" xmltv_id="Discovery turbo Xtra">Discovery turbo Xtra</channel>
+    <channel update="i" site="tvprograma.lt" site_id="fight-sport-hd/0" xmltv_id="Fight Sport HD">Fight Sport HD</channel>
+    <channel update="i" site="tvprograma.lt" site_id="esportstv/352" xmltv_id="ESPORTSTV">ESPORTSTV</channel>
     <channel update="i" site="tvprograma.lt" site_id="tv1000/16" xmltv_id="TV1000">TV1000</channel>
     <channel update="i" site="tvprograma.lt" site_id="tv1000-premium/18" xmltv_id="TV1000 Premium">TV1000 Premium</channel>
     <channel update="i" site="tvprograma.lt" site_id="tv1000-action/183" xmltv_id="TV1000 Action">TV1000 Action</channel>
@@ -53,12 +55,7 @@
     <channel update="i" site="tvprograma.lt" site_id="kinopokaz/272" xmltv_id="Kinopokaz">Kinopokaz</channel>
     <channel update="i" site="tvprograma.lt" site_id="russkij-iliuzionist/243" xmltv_id="Russkij Iliuzionist">Russkij Iliuzionist</channel>
     <channel update="i" site="tvprograma.lt" site_id="teleklub/67" xmltv_id="Teleklub">Teleklub</channel>
-    <channel update="i" site="tvprograma.lt" site_id="tcm/92" xmltv_id="TCM">TCM</channel>
-    <channel update="i" site="tvprograma.lt" site_id="tv1000-comedy/277" xmltv_id="TV1000 Comedy">TV1000 Comedy</channel>
-    <channel update="i" site="tvprograma.lt" site_id="tv1000-comedy-hd/281" xmltv_id="TV1000 Comedy HD">TV1000 Comedy HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="tv1000-premium-hd/275" xmltv_id="TV1000 Premium HD">TV1000 Premium HD</channel>
-    <channel update="i" site="tvprograma.lt" site_id="tv1000-megahit/276" xmltv_id="TV1000 Megahit">TV1000 Megahit</channel>
-    <channel update="i" site="tvprograma.lt" site_id="tv1000-megahit-hd/282" xmltv_id="TV1000 Megahit HD">TV1000 Megahit HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="tvp-seriale/194" xmltv_id="TVP Seriale">TVP Seriale</channel>
     <channel update="i" site="tvprograma.lt" site_id="indija/66" xmltv_id="Indija">Indija</channel>
     <channel update="i" site="tvprograma.lt" site_id="universal/140" xmltv_id="Universal">Universal</channel>
@@ -68,6 +65,8 @@
     <channel update="i" site="tvprograma.lt" site_id="rtl-crime/216" xmltv_id="RTL Crime">RTL Crime</channel>
     <channel update="i" site="tvprograma.lt" site_id="passion/218" xmltv_id="Passion">Passion</channel>
     <channel update="i" site="tvprograma.lt" site_id="retro-tv/242" xmltv_id="Retro TV">Retro TV</channel>
+    <channel update="i" site="tvprograma.lt" site_id="vip-comedy/348" xmltv_id="Vip Comedy">Vip Comedy</channel>
+    <channel update="i" site="tvprograma.lt" site_id="vip-premiere/349" xmltv_id="Vip Premiere">Vip Premiere</channel>
     <channel update="i" site="tvprograma.lt" site_id="tv1000-east/296" xmltv_id="TV1000 East">TV1000 East</channel>
     <channel update="i" site="tvprograma.lt" site_id="k1-movie-channel/285" xmltv_id="K1 movie channel">K1 movie channel</channel>
     <channel update="i" site="tvprograma.lt" site_id="hd1-movie-channel/286" xmltv_id="HD1 movie channel">HD1 movie channel</channel>
@@ -77,6 +76,10 @@
     <channel update="i" site="tvprograma.lt" site_id="filmzone/321" xmltv_id="FilmZone+">FilmZone+</channel>
     <channel update="i" site="tvprograma.lt" site_id="balticum-platinum/322" xmltv_id="Balticum Platinum">Balticum Platinum</channel>
     <channel update="i" site="tvprograma.lt" site_id="muzhskoe-kino/325" xmltv_id="Muzhskoe kino">Muzhskoe kino</channel>
+    <channel update="i" site="tvprograma.lt" site_id="bollywood-tv/334" xmltv_id="Bollywood TV">Bollywood TV</channel>
+    <channel update="i" site="tvprograma.lt" site_id="dom-kino-premium-hd/336" xmltv_id="Dom Kino Premium HD">Dom Kino Premium HD</channel>
+    <channel update="i" site="tvprograma.lt" site_id="vip-megahit/350" xmltv_id="Vip Megahit">Vip Megahit</channel>
+    <channel update="i" site="tvprograma.lt" site_id="tv1000-world-kino/351" xmltv_id="TV1000 World Kino">TV1000 World Kino</channel>
     <channel update="i" site="tvprograma.lt" site_id="rtvi/36" xmltv_id="RTVi">RTVi</channel>
     <channel update="i" site="tvprograma.lt" site_id="sts-ctc/54" xmltv_id="STS-CTC">STS-CTC</channel>
     <channel update="i" site="tvprograma.lt" site_id="ntv/48" xmltv_id="NTV">NTV</channel>
@@ -111,6 +114,9 @@
     <channel update="i" site="tvprograma.lt" site_id="muzyka-pervogo/318" xmltv_id="Muzyka Pervogo">Muzyka Pervogo</channel>
     <channel update="i" site="tvprograma.lt" site_id="peretz-international/324" xmltv_id="Peretz International">Peretz International</channel>
     <channel update="i" site="tvprograma.lt" site_id="komedia-tv/326" xmltv_id="Komedia TV">Komedia TV</channel>
+    <channel update="i" site="tvprograma.lt" site_id="bobior-tv/337" xmltv_id="Bobior TV">Bobior TV</channel>
+    <channel update="i" site="tvprograma.lt" site_id="rbk/341" xmltv_id="RBK">RBK</channel>
+    <channel update="i" site="tvprograma.lt" site_id="perec/347" xmltv_id="Перец">Перец</channel>
     <channel update="i" site="tvprograma.lt" site_id="viasat-explorer/19" xmltv_id="Viasat Explorer">Viasat Explorer</channel>
     <channel update="i" site="tvprograma.lt" site_id="viasat-history/20" xmltv_id="Viasat History">Viasat History</channel>
     <channel update="i" site="tvprograma.lt" site_id="national-geographic/22" xmltv_id="National Geographic">National Geographic</channel>
@@ -146,12 +152,12 @@
     <channel update="i" site="tvprograma.lt" site_id="animal-planet-hd/292" xmltv_id="Animal planet HD">Animal planet HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="oruzhie-tv/299" xmltv_id="Oruzhie TV">Oruzhie TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="bbc-earth/327" xmltv_id="BBC Earth">BBC Earth</channel>
+    <channel update="i" site="tvprograma.lt" site_id="docubox-hd/333" xmltv_id="DocuBox HD">DocuBox HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="sony-entertainment/264" xmltv_id="SONY Entertainment">SONY Entertainment</channel>
     <channel update="i" site="tvprograma.lt" site_id="playboy-tv/132" xmltv_id="Playboy TV">Playboy TV</channel>
-    <channel update="i" site="tvprograma.lt" site_id="entertainment-tv/114" xmltv_id="Entertainment TV">Entertainment TV</channel>
+    <channel update="i" site="tvprograma.lt" site_id="e/114" xmltv_id="E!">E!</channel>
     <channel update="i" site="tvprograma.lt" site_id="blue-hustler/76" xmltv_id="BLUE HUSTLER">BLUE HUSTLER</channel>
     <channel update="i" site="tvprograma.lt" site_id="cbs-reality/91" xmltv_id="CBS Reality">CBS Reality</channel>
-    <channel update="i" site="tvprograma.lt" site_id="cbs-drama/107" xmltv_id="CBS Drama">CBS Drama</channel>
     <channel update="i" site="tvprograma.lt" site_id="ochota-i-rybalka/69" xmltv_id="Ochota i rybalka">Ochota i rybalka</channel>
     <channel update="i" site="tvprograma.lt" site_id="comedy-tv/249" xmltv_id="Comedy TV">Comedy TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="drive-tv/68" xmltv_id="Drive TV">Drive TV</channel>
@@ -165,7 +171,8 @@
     <channel update="i" site="tvprograma.lt" site_id="sony-turbo/293" xmltv_id="Sony Turbo">Sony Turbo</channel>
     <channel update="i" site="tvprograma.lt" site_id="outdoor-channel/295" xmltv_id="Outdoor Channel">Outdoor Channel</channel>
     <channel update="i" site="tvprograma.lt" site_id="trace-sport-stars/304" xmltv_id="Trace Sport Stars">Trace Sport Stars</channel>
-    <channel update="i" site="tvprograma.lt" site_id="crime--investigation/311" xmltv_id="Crime &amp; Investigation">Crime &amp; Investigation</channel>
+    <channel update="i" site="tvprograma.lt" site_id="crime-investigation/311" xmltv_id="Crime &amp; Investigation">Crime &amp; Investigation</channel>
+    <channel update="i" site="tvprograma.lt" site_id="fashion-one-hd/338" xmltv_id="Fashion One HD">Fashion One HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="zvaigzde/212" xmltv_id="Žvaigždė">Žvaigždė</channel>
     <channel update="i" site="tvprograma.lt" site_id="muz-tv/46" xmltv_id="Muz TV">Muz TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="mtv/12" xmltv_id="MTV">MTV</channel>
@@ -188,6 +195,7 @@
     <channel update="i" site="tvprograma.lt" site_id="play-tv/306" xmltv_id="Play TV">Play TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="mtv-live-hd/308" xmltv_id="MTV Live HD">MTV Live HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="mtv-music/309" xmltv_id="MTV Music">MTV Music</channel>
+    <channel update="i" site="tvprograma.lt" site_id="pervyj-muzikalnij/339" xmltv_id="Pervyj Muzikalnij">Pervyj Muzikalnij</channel>
     <channel update="i" site="tvprograma.lt" site_id="cartoon-network/77" xmltv_id="Cartoon Network">Cartoon Network</channel>
     <channel update="i" site="tvprograma.lt" site_id="boomerang/111" xmltv_id="Boomerang">Boomerang</channel>
     <channel update="i" site="tvprograma.lt" site_id="nickelodeon/90" xmltv_id="Nickelodeon">Nickelodeon</channel>
@@ -206,13 +214,12 @@
     <channel update="i" site="tvprograma.lt" site_id="duck-tv/283" xmltv_id="Duck TV">Duck TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="duck-tv-hd/284" xmltv_id="Duck TV HD">Duck TV HD</channel>
     <channel update="i" site="tvprograma.lt" site_id="nickelodeon-hd/310" xmltv_id="Nickelodeon HD">Nickelodeon HD</channel>
+    <channel update="i" site="tvprograma.lt" site_id="kidzone/346" xmltv_id="Kidzone+">Kidzone+</channel>
     <channel update="i" site="tvprograma.lt" site_id="lrt-lituanica/196" xmltv_id="LRT LITUANICA">LRT LITUANICA</channel>
     <channel update="i" site="tvprograma.lt" site_id="init/147" xmltv_id="Init">Init</channel>
     <channel update="i" site="tvprograma.lt" site_id="pukas-tv/178" xmltv_id="Pūkas TV">Pūkas TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="balticum/102" xmltv_id="Balticum">Balticum</channel>
     <channel update="i" site="tvprograma.lt" site_id="dzukijos-tv/148" xmltv_id="Dzūkijos TV">Dzūkijos TV</channel>
-    <channel update="i" site="tvprograma.lt" site_id="pantv/144" xmltv_id="PanTV">PanTV</channel>
-    <channel update="i" site="tvprograma.lt" site_id="splius/142" xmltv_id="Splius">Splius</channel>
     <channel update="i" site="tvprograma.lt" site_id="stv/145" xmltv_id="STV">STV</channel>
     <channel update="i" site="tvprograma.lt" site_id="tv3-latvia/185" xmltv_id="TV3 Latvia">TV3 Latvia</channel>
     <channel update="i" site="tvprograma.lt" site_id="rtl/32" xmltv_id="RTL">RTL</channel>
@@ -243,7 +250,14 @@
     <channel update="i" site="tvprograma.lt" site_id="nhk-world/240" xmltv_id="NHK World">NHK World</channel>
     <channel update="i" site="tvprograma.lt" site_id="rosija-today/247" xmltv_id="Rosija today">Rosija today</channel>
     <channel update="i" site="tvprograma.lt" site_id="tele5/236" xmltv_id="Tele5">Tele5</channel>
+    <channel update="i" site="tvprograma.lt" site_id="gntv/329" xmltv_id="GNTV">GNTV</channel>
     <channel update="i" site="tvprograma.lt" site_id="init-ekstra-tv/305" xmltv_id="Init Ekstra TV">Init Ekstra TV</channel>
     <channel update="i" site="tvprograma.lt" site_id="marijampoles-televizija/319" xmltv_id="Marijampolės televizija">Marijampolės televizija</channel>
+    <channel update="i" site="tvprograma.lt" site_id="currenttime/335" xmltv_id="CurrentTime">CurrentTime</channel>
+    <channel update="i" site="tvprograma.lt" site_id="seimas-tiesiogiai/340" xmltv_id="Seimas Tiesiogiai">Seimas Tiesiogiai</channel>
+    <channel update="i" site="tvprograma.lt" site_id="rtl-passion/342" xmltv_id="RTL Passion">RTL Passion</channel>
+    <channel update="i" site="tvprograma.lt" site_id="n-tv/343" xmltv_id="n-tv">n-tv</channel>
+    <channel update="i" site="tvprograma.lt" site_id="rtl-plus/344" xmltv_id="RTL plus">RTL plus</channel>
+    <channel update="i" site="tvprograma.lt" site_id="geo-television/345" xmltv_id="GEO Television">GEO Television</channel>
   </channels>
 </site>

--- a/siteini.pack/Lithuania/tvprograma.lt.ini
+++ b/siteini.pack/Lithuania/tvprograma.lt.ini
@@ -3,6 +3,10 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: tvprograma.lt
 * @MinSWversion: V1.1.1/53
+* @Revision 3 -	[09/09/2018] Erikas Rudinskas
+*	- Fix currently active TV show not being added
+*   - Fix TV show description
+*   - Updated broken channels generation
 * @Revision 2 -	[12/03/2016] Blackbear199
 *	- fix showsplit
 * @Revision 1 -	[08/09/2015] Karolis Vaikutis
@@ -15,7 +19,7 @@
 **------------------------------------------------------------------------------------------------
 
 site {url=tvprograma.lt|timezone=Europe/Vilnius|maxdays=8|cultureinfo=lt-LT|charset=UTF-8|titlematchfactor=90|episodesystem=onscreen|allowlastpageoverflow}
-url_index{url|http://www.tvprograma.lt/tv-programa/televizija/|channel|/|urldate|}
+url_index{url|https://www.tvprograma.lt/tv-programa/televizija/|channel|/|urldate|}
 url_index.headers {customheader=Accept-Encoding=gzip,deflate}
 urldate.format {datestring|yyyy_MM_dd}
 *
@@ -34,8 +38,8 @@ index_title.modify {cleanup(tags="<"">")}
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
 **
 ** @auto_xml_channel_start
-*url_index{url|http://www.tvprograma.lt}
-*index_site_id.scrub {multi|<div class="tab-pane|<a href="http://www.tvprograma.lt/tv-programa/televizija/|?genre|<div id="top-low-banner">}
+*url_index{url|https://www.tvprograma.lt}
+*index_site_id.scrub {multi|<div class="tab-pane|<a href="https://www.tvprograma.lt/tv-programa/televizija/|?genre|<div id="top-low-banner">}
 *index_site_channel.scrub {multi|<div class="tab-pane|title="|">|<div id="top-low-banner">}
 *scope.range {(channellist)|end}
 *index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}

--- a/siteini.pack/Lithuania/tvprograma.lt.ini
+++ b/siteini.pack/Lithuania/tvprograma.lt.ini
@@ -19,16 +19,16 @@ url_index{url|http://www.tvprograma.lt/tv-programa/televizija/|channel|/|urldate
 url_index.headers {customheader=Accept-Encoding=gzip,deflate}
 urldate.format {datestring|yyyy_MM_dd}
 *
-index_showsplit.scrub {multi|<div href="#" class="item name">|||<div class="c-banner">}
+index_showsplit.scrub {multi|<div href="#" class="item name|||<div class="c-banner">}
 *
 index_start.scrub {single|<span>||</span>|</span>}
 index_title.scrub {single|</span>||<div class|<div class}
-index_description.scrub {multi|<div class="description|>|</div>|</div>}
+index_description.scrub {regex||<div class="description">(.*?)</div>||}
+index_description.scrub {regex||<div class="full-description" style="display:none;">(.*?)</div>||}
 index_showicon.scrub {single|<img src="||"/>|"/>}
 *
 index_title.modify {cleanup}
 index_title.modify {cleanup(tags="<"">")}
-index_description.modify {cleanup(removeduplicates=equal,100)}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)


### PR DESCRIPTION
This is updated ini and channels for Lithuanian site. What this pull request changes:

tvprograma.lt
--------------------------------------------------------------
1. Updates channels list (I re-generated them).
2. Update channels generation code. (it was completely broken)
3. Update TV show description parsing (it was partially broken)
4. Old config was not getting currently active show. I fixed it too.

cgates.lt
--------------------------------------------------------------
1. Rewrote channels generation as well as script to get EPG data. Everything was broken since page got completelly changed. Now everything works.

viasat.lt
--------------------------------------------------------------
1. New site added

24tv.lt
--------------------------------------------------------------
1. Channels update