### PR TITLE
Corrected tvtv.us and tvtv.ca to correctly handle multiple days.

### DIFF
--- a/siteini.pack/Canada/tvtv.ca.ini
+++ b/siteini.pack/Canada/tvtv.ca.ini
@@ -28,7 +28,7 @@ urldate.format {datestring|yyyy-MM-dd}
 **
 url_index.headers {accept=application/json, text/javascript, */*}
 **
-index_showsplit.scrub {regex||"listings"\:\[\s*(\{.*?"showHost".*?\},?\s*)+.*?\].*||}
+index_showsplit.scrub {regex||"listings"\:\[\s*(\{.*?"showHost".*?\},?\s*)+.*?||}
 **
 index_variable_element.modify {set|'config_site_id'}
 global_temp_3.scrub {regex||\{\s*"channel":\{.*?"logoFilename":"(.*?)"\,?.*?"listings".*]||}

--- a/siteini.pack/USA/tvtv.us.ini
+++ b/siteini.pack/USA/tvtv.us.ini
@@ -28,7 +28,7 @@ urldate.format {datestring|yyyy-MM-dd}
 **
 url_index.headers {accept=application/json, text/javascript, */*}
 **
-index_showsplit.scrub {regex||"listings"\:\[\s*(\{.*?"showHost".*?\},?\s*)+.*?\].*||}
+index_showsplit.scrub {regex||"listings"\:\[\s*(\{.*?"showHost".*?\},?\s*)+.*?||}
 **
 index_variable_element.modify {set|'config_site_id'}
 global_temp_3.scrub {regex||\{\s*"channel":\{.*?"logoFilename":"(.*?)"\,?.*?"listings".*]||}


### PR DESCRIPTION
Corrected tvtv.us and tvtv.ca to correctly handle multiple days. 

The regex was cutting off the extra days because it seems the fetched data is concatenated into a single stream. Matching the end of the previous day's data as the end of the showsplit caused it to stop after the first day's programming.

Solution is to allow it to run to the end of the received data. This could (and probably will) result in duplicate shows. But the built in detection seems to find and remove them.