### PR TITLE
Improve parsing of json of yelotv.be

### DIFF
--- a/siteini.pack/Belgium/yelotv.be.ini
+++ b/siteini.pack/Belgium/yelotv.be.ini
@@ -3,6 +3,8 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: yelotv.be
 * @MinSWversion: V1.1.1/52
+* @Revision 5 - [29/12/2018] Michaël Arnauts
+* Improve json parsing
 * @Revision 4 - [04/06/2017] Netuddki
 * cleanup special characters
 * @Revision 3 - [24/05/2017] Netuddki
@@ -34,35 +36,33 @@ index_urlshow.modify {addstart|https://www.yeloplay.be/api/pubba/v1/events/detai
 *
 index_start.scrub {regex||"starttime":(.*?),"||}
 index_stop.scrub {regex||"endtime":(.*?),"||}
-index_title.scrub {regex||"title":"(.*?)","||}
-index_title.modify {cleanup}
+index_title.scrub {regex||^.*?"title"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+index_title.modify {cleanup(style=jsondecode)}
 *
-title.scrub {regex||"title":"(.*?)","||}
-title.modify {cleanup}
-subtitle.scrub {regex||"subtitle":"(.*?)","||}
-subtitle.modify {cleanup}
-description.scrub {regex||"longsynopsis":"(.*?)","||}
-description.modify {cleanup}
-category.scrub {regex||"contentlabel":"(.*?)","||}
-category.modify {cleanup}
-showicon.scrub {regex||"image":"(.*?)","||}
-showicon.modify {remove|\}
-country.scrub {regex||"location":"(.*?)","||}
-productiondate.scrub {regex||"year":(.*?),"||}
+title.scrub {regex||^.*?"title"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+title.modify {cleanup(style=jsondecode)}
+subtitle.scrub {regex||^.*?"subtitle"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+subtitle.modify {cleanup(style=jsondecode)}
+description.scrub {regex||^.*?"longsynopsis"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+description.modify {cleanup(style=jsondecode)}
+category.scrub {regex||^.*?"contentlabel"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+category.modify {cleanup(style=jsondecode)}
+showicon.scrub {regex||^.*?"image"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+showicon.modify {cleanup(style=jsondecode)}
+country.scrub {regex||^.*?"location"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+country.modify {cleanup(style=jsondecode)}
+productiondate.scrub {regex||^.*?"year"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+productiondate.modify {cleanup(style=jsondecode)}
 *
 temp_1.scrub {regex||"season":([1-9]+)||}
-
 temp_1.modify {addstart('temp_1' not "")|S}
-
 temp_2.scrub {regex||"episode":([1-9]+)||}
-
 temp_2.modify {addstart('temp_2' not "")|E}
-
 temp_2.modify {addstart('temp_1' not "")|'temp_1'}
-
 episode.modify {set(pattern="S'S1'E'E1'""E'E1'""S'S1'")|'temp_2'}
-actor.scrub {regex||"name":"(.*?)"}||}
-actor.modify {cleanup}
+*
+actor.scrub {regex||^.*?"name"\s*:\s*"([^"\\]*(?:\\.[^"\\]*)*)"||}
+actor.modify {cleanup(style=jsondecode)}
 
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)


### PR DESCRIPTION
The previous way of parsing left backslashes in place and didn't handle all cases of escaping. This change uses a regex that is commonly used to parse json on other channel.ini files.