### PR TITLE
Fix time parsing error for Slovenia/sportklub.info

### DIFF
--- a/siteini.pack/Slovenia/sportklub.info.ini
+++ b/siteini.pack/Slovenia/sportklub.info.ini
@@ -29,7 +29,7 @@ index_variable_element.modify {substring(type=regex)|'config_site_id' "##(\d+)$"
 *
 index_showsplit.scrub {multi(includeblock='index_variable_element')|<ul class="epg-item-row">|<li class="epg-item"|</li>|</ul>}
 *
-index_start.scrub {single|<span class="time">|,|</span>|</div>}
+index_start.scrub {single(pattern="dd.MM.yyyy HH.mm")|<span class="time">|,|</span>|</div>}
 index_start.modify {remove| -}
 index_duration.scrub {single|style="width: ||em;">|em;">}
 index_duration.modify {calculate(format=F0)|3 *}


### PR DESCRIPTION
Using this ini file for long time. A few days ago it stopped working. because of

```
(   1/8   ) SPORTKLUB.INFO -- chan. (xmltv_id=SI-SK 3) -- mode Incremental
iiiiiiii
Unable to update channel SI-SK 3
Generic syntax exception:
   message:
Current culture: en-GB
time parsing error : String was not recognized as a valid DateTime.
startdatetime time scrubbed : 20.02.2019 08.30
computer date/time format: 20/02/2019 09:29:56
Existing guide data restored!
```
so I added some date parsing code!