### PR TITLE
Fix bein.net.ini and add extraction of descriptions

### DIFF
--- a/siteini.pack/International/bein.net.ini
+++ b/siteini.pack/International/bein.net.ini
@@ -3,6 +3,9 @@
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: bein.net
 * @MinSWversion: V1.57
+* @Revision 15 - [02/20/2019] orhan
+*   - Fix timeshift (programme dates would always be 1 day ahead)
+*   - Added descriptions to programme items
 * @Revision 14 - [12/06/2018] Fazzani Heni
 *   - Fix extract xmltv_id and site_id
 *   - Added bein max channels
@@ -30,9 +33,9 @@
 * @Remarks: changed name to beinsports.net,added french option
 * @header_end
 **------------------------------------------------------------------------------------------------
-site {url=bein.net|timezone=UTC+03:00|maxdays=7|cultureinfo=en-US|charset=UTF-8|titlematchfactor=90}
+site {url=bein.net|timezone=UTC|maxdays=7|cultureinfo=en-AU|charset=UTF-8|titlematchfactor=90|firstshow=1}
 *
-url_index{url|http://epg.beinsports.com/utctime##country##.php?cdate=|urldate|&offset=3&category=##genre##&id=123}
+url_index{url|http://epg.beinsports.com/utctime##country##.php?cdate=|urldate|&offset=0&mins=00&category=##genre##&id=123}
 url_index.headers {customheader=Accept-Encoding=gzip,deflate}
 urldate.format {datestring|yyyy-MM-dd}
 *
@@ -54,6 +57,7 @@ index_start.scrub {single(separator="-" include=first)|<p class=time>||<|<}
 index_stop.scrub {single(separator="-" include=last)|<p class=time>||<|<}
 index_title.scrub {single|<p class=title>||</p>|</p>}
 index_category.scrub {single(separator=", ")|<p class=format>||</p>|</p>}
+index_description.scrub {single|data-desc='||'|'}
 
 index_episode.modify {substring(type=regex)|'index_title' "(Ep\d+)"}
 index_title.modify {remove|'index_episode'}


### PR DESCRIPTION
This was fixed once in a previous commit, but got overwritten somehow.
I also added descriptions to programme items (only tested on beIN Sports Australia for now, but should working across all beIN tv guides)