### PR TITLE
fix tv.mail.ru channel list parsing

### DIFF
--- a/siteini.pack/Russia/tv.mail.ru.ini
+++ b/siteini.pack/Russia/tv.mail.ru.ini
@@ -67,7 +67,7 @@ rating.modify {set(6")|18+}
 ** @auto_xml_channel_start
 *url_index{url|https://tv.mail.ru/ajax/channel/index/?region_id=70&page=|subpage|}
 *subpage.format {list(format=D1 step=1 count=40)|1}
-*index_site_id.scrub {multi|"channel":[|"id":"|"}|]}
+*index_site_id.scrub {multi|"channel":[|"id":"|"|]}
 *index_site_channel.scrub {multi|"channel":[|"name":"|",|]}
 *index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}
 ** @auto_xml_channel_end


### PR DESCRIPTION
Fixes #455 
Here is the fragment with "id" which is parsed wrong:
```
{"pic_url":"/pic/channel_logo/32x32/b/44/097d3f3be9fc5af7e3cb7949784d0.png","has_live":1,"url":"/moskva/channel/850/","name":"Первый","id":"850","pic_url_64":"/pic/channel_logo/64x64/5/9d/3fe6255e3c44166333f9ee41823fb.png","is_promo":0}