### PR TITLE
Fixes and improvements for 3 sites from Poland

### DIFF
--- a/siteini.pack/Poland/programtv.interia.pl.channels.xml
+++ b/siteini.pack/Poland/programtv.interia.pl.channels.xml
@@ -1,297 +1,296 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version 1.54.6/0.01 -- Jan van Straaten" site="programtv.interia.pl">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.1.11.0 -- Jan van Straaten" site="programtv.interia.pl">
   <channels>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-13-ulica,page,pl-name,cid,20915229" xmltv_id="13 Ulica">13 Ulica</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-13-ulica-hd,page,pl-name,cid,69033907" xmltv_id="13 Ulica HD">13 Ulica HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-4fun-fitanddance,page,pl-name,cid,24842601" xmltv_id="4FUN FIT&amp;DANCE">4FUN FIT&amp;DANCE</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-4fun-hits,page,pl-name,cid,20909115" xmltv_id="4FUN HITS">4FUN HITS</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-4fun-tv,page,pl-name,cid,20872501" xmltv_id="4FUN.TV">4FUN.TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-adventure,page,pl-name,cid,52460227" xmltv_id="Adventure">Adventure</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-adventure-hd,page,pl-name,cid,52460504" xmltv_id="Adventure HD">Adventure HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-ale-kino,page,pl-name,cid,20916850" xmltv_id="Ale kino+">Ale kino+</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-ale-kino-hd,page,pl-name,cid,25684497" xmltv_id="Ale kino+ HD">Ale kino+ HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-amc,page,pl-name,cid,20883217" xmltv_id="AMC">AMC</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-animal-planet,page,pl-name,cid,20907854" xmltv_id="Animal Planet">Animal Planet</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-atm-rozrywka,page,pl-name,cid,30923643" xmltv_id="ATM Rozrywka">ATM Rozrywka</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn,page,pl-name,cid,20833227" xmltv_id="AXN">AXN</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-black,page,pl-name,cid,20878566" xmltv_id="AXN Black">AXN Black</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-hd,page,pl-name,cid,20911492" xmltv_id="AXN HD">AXN HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-spin,page,pl-name,cid,27148909" xmltv_id="AXN Spin">AXN Spin</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-spin-hd,page,pl-name,cid,45367726" xmltv_id="AXN Spin HD">AXN Spin HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-white,page,pl-name,cid,20878407" xmltv_id="AXN White">AXN White</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-baby-tv,page,pl-name,cid,20909214" xmltv_id="Baby TV">Baby TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-babyfirsttv,page,pl-name,cid,20906031" xmltv_id="BabyFirstTV">BabyFirstTV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-brit,page,pl-name,cid,20892106" xmltv_id="BBC Brit">BBC Brit</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-cbeebies,page,pl-name,cid,20892336" xmltv_id="BBC CBeebies">BBC CBeebies</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-earth,page,pl-name,cid,20893043" xmltv_id="BBC Earth">BBC Earth</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-hd,page,pl-name,cid,20859632" xmltv_id="BBC HD">BBC HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-knowledge-hd,page,pl-name,cid,20863712" xmltv_id="BBC Knowledge HD">BBC Knowledge HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-lifestyle,page,pl-name,cid,20893216" xmltv_id="BBC Lifestyle">BBC Lifestyle</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-boomerang,page,pl-name,cid,20875977" xmltv_id="Boomerang">Boomerang</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal,page,pl-name,cid,20832249" xmltv_id="CANAL+">CANAL+</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-discovery,page,pl-name,cid,59830186" xmltv_id="CANAL+ Discovery">CANAL+ Discovery</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-discovery-hd,page,pl-name,cid,59864094" xmltv_id="CANAL+ Discovery HD">CANAL+ Discovery HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-family,page,pl-name,cid,37499941" xmltv_id="CANAL+ Family">CANAL+ Family</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-family-hd,page,pl-name,cid,37500465" xmltv_id="CANAL+ Family HD">CANAL+ Family HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-film,page,pl-name,cid,20916995" xmltv_id="CANAL+ Film">CANAL+ Film</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-film-hd,page,pl-name,cid,20899951" xmltv_id="CANAL+ Film HD">CANAL+ Film HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-hd,page,pl-name,cid,20913424" xmltv_id="CANAL+ HD">CANAL+ HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-seriale,page,pl-name,cid,37499682" xmltv_id="CANAL+ Seriale">CANAL+ Seriale</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-seriale-hd,page,pl-name,cid,37500989" xmltv_id="CANAL+ Seriale HD">CANAL+ Seriale HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport,page,pl-name,cid,20916996" xmltv_id="CANAL+ Sport">CANAL+ Sport</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport-2,page,pl-name,cid,59587547" xmltv_id="CANAL+ Sport 2">CANAL+ Sport 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport-2-hd,page,pl-name,cid,59864427" xmltv_id="CANAL+ Sport 2 HD">CANAL+ Sport 2 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport-hd,page,pl-name,cid,20900147" xmltv_id="CANAL+ Sport HD">CANAL+ Sport HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-1,page,pl-name,cid,37500201" xmltv_id="CANAL+1">CANAL+1</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-1-hd,page,pl-name,cid,37500725" xmltv_id="CANAL+1 HD">CANAL+1 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cartoon-network,page,pl-name,cid,20886775" xmltv_id="Cartoon Network">Cartoon Network</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cbs-action,page,pl-name,cid,20915424" xmltv_id="CBS Action">CBS Action</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cbs-europa,page,pl-name,cid,20915866" xmltv_id="CBS Europa">CBS Europa</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cbs-reality,page,pl-name,cid,20916555" xmltv_id="CBS Reality">CBS Reality</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-ci-polsat,page,pl-name,cid,20838196" xmltv_id="CI POLSAT">CI POLSAT</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax,page,pl-name,cid,20879298" xmltv_id="Cinemax">Cinemax</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax-2,page,pl-name,cid,20876522" xmltv_id="Cinemax 2">Cinemax 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax-2-hd,page,pl-name,cid,20913423" xmltv_id="Cinemax 2 HD">Cinemax 2 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax-hd,page,pl-name,cid,20859862" xmltv_id="Cinemax HD">Cinemax HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-comedy-central,page,pl-name,cid,20879299" xmltv_id="Comedy Central">Comedy Central</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-comedy-central-family,page,pl-name,cid,20876656" xmltv_id="Comedy Central Family">Comedy Central Family</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-csb-tv,page,pl-name,cid,20911757" xmltv_id="CSB TV">CSB TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-czworka-polskie-radio,pagEleven Sports 1e,pl-name,cid,20913114" xmltv_id="Czwórka Polskie Radio">Czwórka Polskie Radio</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-da-vinci,page,pl-name,cid,20891002" xmltv_id="Da Vinci">Da Vinci</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-disco-polo-music,page,pl-name,cid,48623077" xmltv_id="Disco Polo Music">Disco Polo Music</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-channel,page,pl-name,cid,20914054" xmltv_id="Discovery Channel">Discovery Channel</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-channel-hd,page,pl-name,cid,20882598" xmltv_id="Discovery Channel HD">Discovery Channel HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-historia,page,pl-name,cid,20882858" xmltv_id="Discovery Historia">Discovery Historia</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-life,page,pl-name,cid,20913506" xmltv_id="Discovery Life">Discovery Life</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-science,page,pl-name,cid,20919134" xmltv_id="Discovery Science">Discovery Science</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-turbo-xtra,page,pl-name,cid,20919399" xmltv_id="Discovery Turbo Xtra">Discovery Turbo Xtra</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-turbo-xtra-hd,page,pl-name,cid,47963140" xmltv_id="Discovery Turbo Xtra HD">Discovery Turbo Xtra HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-disney-channel,page,pl-name,cid,20874161" xmltv_id="Disney Channel">Disney Channel</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-disney-junior,page,pl-name,cid,20873088" xmltv_id="Disney Junior">Disney Junior</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-disney-xd,page,pl-name,cid,20914870" xmltv_id="Disney XD">Disney XD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-dlaciebie-tv,page,pl-name,cid,31692370" xmltv_id="dlaCiebie.tv">dlaCiebie.tv</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-docubox-hd,page,pl-name,cid,43362279" xmltv_id="DocuBox HD">DocuBox HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-domo,page,pl-name,cid,20901927" xmltv_id="Domo+">Domo+</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-domo-hd,page,pl-name,cid,25684984" xmltv_id="Domo+ HD">Domo+ HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-duck-tv,page,pl-name,cid,20896315" xmltv_id="Duck TV">Duck TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-duck-tv-hd,page,pl-name,cid,34036627" xmltv_id="Duck TV HD">Duck TV HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-e-entertaiment-hd,page,pl-name,cid,41121255" xmltv_id="E! Entertaiment HD">E! Entertaiment HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-e-entertainment,page,pl-name,cid,20887377" xmltv_id="E! Entertainment">E! Entertainment</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-edusat,page,pl-name,cid,20872729" xmltv_id="Edusat">Edusat</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-edusat-hd,page,pl-name,cid,34358070" xmltv_id="Edusat HD">Edusat HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-1,page,pl-name,cid,63020620" xmltv_id="Eleven Sports 1">Eleven Sports 1</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-1-hd,page,pl-name,cid,67360876" xmltv_id="Eleven Sports 1 HD">Eleven Sports 1 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-2,page,pl-name,cid,63029815" xmltv_id="Eleven Sports 2">Eleven Sports 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-2-hd,page,pl-name,cid,67361119" xmltv_id="Eleven Sports 2 HD">Eleven Sports 2 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-3,page,pl-name,cid,77007149" xmltv_id="Eleven Sports 3">Eleven Sports 3</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-3-hd,page,pl-name,cid,77124853" xmltv_id="Eleven Sports 3 HD">Eleven Sports 3 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-4,page,pl-name,cid,90643965" xmltv_id="Eleven Sports 4">Eleven Sports 4</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-4-hd,page,pl-name,cid,94587855" xmltv_id="Eleven Sports 4 HD">Eleven Sports 4 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-english-club-tv,page,pl-name,cid,31868352" xmltv_id="English Club TV">English Club TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eska-rock-tv,page,pl-name,cid,70432907" xmltv_id="Eska Rock TV">Eska Rock TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eska-tv,page,pl-name,cid,20906550" xmltv_id="Eska TV">Eska TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eska-tv-extra,page,pl-name,cid,84225806" xmltv_id="Eska TV Extra">Eska TV Extra</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurochannel,page,pl-name,cid,45447505" xmltv_id="Eurochannel">Eurochannel</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-1,page,pl-name,cid,20900411" xmltv_id="Eurosport 1">Eurosport 1</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-1-hd,page,pl-name,cid,20900276" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-2,page,pl-name,cid,20890823" xmltv_id="Eurosport 2">Eurosport 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-2-hd,page,pl-name,cid,20908509" xmltv_id="Eurosport 2 HD">Eurosport 2 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-extreme,page,pl-name,cid,20915601" xmltv_id="Extreme">Extreme</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-family-sport,page,pl-name,cid,43062622" xmltv_id="Family Sport">Family Sport</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-family-sport-hd,page,pl-name,cid,42949027" xmltv_id="Family Sport HD">Family Sport HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fashion-one,page,pl-name,cid,33409784" xmltv_id="Fashion One">Fashion One</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fashion-one-hd,page,pl-name,cid,34036349" xmltv_id="Fashion One HD">Fashion One HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fightbox-hd,page,pl-name,cid,30660243" xmltv_id="FightBox HD">FightBox HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fightklub,page,pl-name,cid,20888671" xmltv_id="FightKlub">FightKlub</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fightklub-hd,page,pl-name,cid,41122509" xmltv_id="Fightklub HD">Fightklub HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox,page,pl-name,cid,20891371" xmltv_id="Filmbox">Filmbox</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-action,page,pl-name,cid,32750767" xmltv_id="FilmBox Action">FilmBox Action</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-arthouse,page,pl-name,cid,45826521" xmltv_id="FilmBox Arthouse">FilmBox Arthouse</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-extra-hd,page,pl-name,cid,20891963" xmltv_id="FilmBox Extra HD">FilmBox Extra HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-family,page,pl-name,cid,20901645" xmltv_id="Filmbox Family">Filmbox Family</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-premium,page,pl-name,cid,20891825" xmltv_id="FilmBox Premium">FilmBox Premium</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fokus-tv,page,pl-name,cid,48284912" xmltv_id="Fokus TV">Fokus TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox,page,pl-name,cid,20911996" xmltv_id="FOX">FOX</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox-comedy,page,pl-name,cid,20884527" xmltv_id="Fox Comedy">Fox Comedy</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox-comedy-hd,page,pl-name,cid,20858786" xmltv_id="Fox Comedy HD">Fox Comedy HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox-hd,page,pl-name,cid,20912237" xmltv_id="FOX HD">FOX HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-ginx-tv,page,pl-name,cid,34743591" xmltv_id="GINX TV">GINX TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-golf-channel,page,pl-name,cid,81067471" xmltv_id="Golf Channel">Golf Channel</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-golf-channel-hd,page,pl-name,cid,81067720" xmltv_id="Golf Channel HD">Golf Channel HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-h2,page,pl-name,cid,54186261" xmltv_id="H2">H2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-h2-hd,page,pl-name,cid,54219062" xmltv_id="H2 HD">H2 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo,page,pl-name,cid,20833599" xmltv_id="HBO">HBO</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo-hd,page,pl-name,cid,20900275" xmltv_id="HBO HD">HBO HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo2,page,pl-name,cid,20830747" xmltv_id="HBO2">HBO2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo2-hd,page,pl-name,cid,20913421" xmltv_id="HBO2 HD">HBO2 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo3,page,pl-name,cid,20886553" xmltv_id="HBO3">HBO3</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo3-hd,page,pl-name,cid,20913422" xmltv_id="HBO3 HD">HBO3 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-history,page,pl-name,cid,20895304" xmltv_id="HISTORY">HISTORY</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-history-hd,page,pl-name,cid,20895772" xmltv_id="HISTORY HD">HISTORY HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-id,page,pl-name,cid,20906723" xmltv_id="ID">ID</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-id-hd,page,pl-name,cid,47963109" xmltv_id="ID HD">ID HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-jimjam-polsat,page,pl-name,cid,20893922" xmltv_id="JimJam Polsat">JimJam Polsat</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-kino-polska,page,pl-name,cid,20825341" xmltv_id="Kino Polska">Kino Polska</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-kino-polska-muzyka,page,pl-name,cid,21965593" xmltv_id="Kino Polska Muzyka">Kino Polska Muzyka</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-kuchnia,page,pl-name,cid,20878933" xmltv_id="Kuchnia+">Kuchnia+</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-kuchnia-hd,page,pl-name,cid,25684935" xmltv_id="Kuchnia+ HD">Kuchnia+ HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-lifetime,page,pl-name,cid,55306381" xmltv_id="Lifetime">Lifetime</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-love,page,pl-name,cid,20890188" xmltv_id="LOVE">LOVE</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-mango,page,pl-name,cid,20904509" xmltv_id="Mango">Mango</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-metro,page,pl-name,cid,77128432" xmltv_id="METRO">METRO</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-metro-hd,page,pl-name,cid,77128511" xmltv_id="METRO HD">METRO HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-minimini,page,pl-name,cid,20915980" xmltv_id="MiniMini+">MiniMini+</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-minimini-hd,page,pl-name,cid,25685026" xmltv_id="MiniMini+ HD">MiniMini+ HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-mtv-music,page,pl-name,cid,20918680" xmltv_id="MTV Music">MTV Music</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-mtv-polska,page,pl-name,cid,20827512" xmltv_id="MTV Polska">MTV Polska</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nat-geo-people-hd,page,pl-name,cid,63755427" xmltv_id="Nat Geo People HD">Nat Geo People HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nat-geo-wild,page,pl-name,cid,20888462" xmltv_id="Nat Geo Wild">Nat Geo Wild</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nat-geo-wild-hd,page,pl-name,cid,20908152" xmltv_id="Nat Geo Wild HD">Nat Geo Wild HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-national-geographic,page,pl-name,cid,20915414" xmltv_id="National Geographic">National Geographic</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-national-geographic-hd,page,pl-name,cid,20888256" xmltv_id="National Geographic HD">National Geographic HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nhk-world-tv,page,pl-name,cid,33471159" xmltv_id="NHK World TV">NHK World TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nick-jr,page,pl-name,cid,21492375" xmltv_id="Nick Jr.">Nick Jr.</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nickelodeon,page,pl-name,cid,20900855" xmltv_id="Nickelodeon">Nickelodeon</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nickelodeon-hd,page,pl-name,cid,24866540" xmltv_id="Nickelodeon HD">Nickelodeon HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-novela-tv,page,pl-name,cid,31711335" xmltv_id="Novela tv">Novela tv</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-novela-tv-hd,page,pl-name,cid,34330427" xmltv_id="Novela tv HD">Novela tv HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nowa-tv,page,pl-name,cid,76305294" xmltv_id="Nowa TV">Nowa TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nowa-tv-hd,page,pl-name,cid,76570733" xmltv_id="Nowa TV HD">Nowa TV HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nsport,page,pl-name,cid,20883216" xmltv_id="nSport">nSport</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-nsport-hd,page,pl-name,cid,20837937" xmltv_id="nSport HD">nSport HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-paramount-channel-hd,page,pl-name,cid,23150731" xmltv_id="Paramount Channel HD">Paramount Channel HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-planete,page,pl-name,cid,20836142" xmltv_id="Planete+">Planete+</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-planete-hd,page,pl-name,cid,25684913" xmltv_id="PLANETE+ HD">PLANETE+ HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polo-tv,page,pl-name,cid,22358930" xmltv_id="Polo TV">Polo TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polonia-1,page,pl-name,cid,20826441" xmltv_id="Polonia 1">Polonia 1</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat,page,pl-name,cid,20825644" xmltv_id="Polsat">Polsat</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-2,page,pl-name,cid,20825920" xmltv_id="Polsat 2">Polsat 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-cafe,page,pl-name,cid,20902523" xmltv_id="Polsat Café">Polsat Café</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-doku,page,pl-name,cid,79468518" xmltv_id="POLSAT Doku">POLSAT Doku</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-doku-hd,page,pl-name,cid,79583195" xmltv_id="POLSAT Doku HD">POLSAT Doku HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-film,page,pl-name,cid,20908510" xmltv_id="Polsat Film">Polsat Film</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-film-hd,page,pl-name,cid,35424992" xmltv_id="POLSAT Film HD">POLSAT Film HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-food,page,pl-name,cid,34502467" xmltv_id="POLSAT Food">POLSAT Food</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-food-network-hd,page,pl-name,cid,61052040" xmltv_id="POLSAT Food Network HD">POLSAT Food Network HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-hd,page,pl-name,cid,20908413" xmltv_id="Polsat HD">Polsat HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-music-hd,page,pl-name,cid,53371105" xmltv_id="Polsat Music HD">Polsat Music HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-news,page,pl-name,cid,20900413" xmltv_id="Polsat News">Polsat News</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-news-2,page,pl-name,cid,20871594" xmltv_id="Polsat News 2">Polsat News 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-news-hd,page,pl-name,cid,45873361" xmltv_id="POLSAT News HD">POLSAT News HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-play,page,pl-name,cid,20902237" xmltv_id="Polsat Play">Polsat Play</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-romans,page,pl-name,cid,41377056" xmltv_id="POLSAT Romans">POLSAT Romans</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport,page,pl-name,cid,20829758" xmltv_id="Polsat Sport">Polsat Sport</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-extra,page,pl-name,cid,20876428" xmltv_id="Polsat Sport Extra">Polsat Sport Extra</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-extra-hd,page,pl-name,cid,30542018" xmltv_id="Polsat Sport Extra HD">Polsat Sport Extra HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-fight-hd,page,pl-name,cid,73401252" xmltv_id="Polsat Sport Fight HD">Polsat Sport Fight HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-hd,page,pl-name,cid,20899857" xmltv_id="Polsat Sport HD">Polsat Sport HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-news,page,pl-name,cid,21985309" xmltv_id="Polsat Sport News">Polsat Sport News</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-1,page,pl-name,cid,98571860" xmltv_id="POLSAT Sport Premium 1">POLSAT Sport Premium 1</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-2,page,pl-name,cid,98572021" xmltv_id="POLSAT Sport Premium 2">POLSAT Sport Premium 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-3,page,pl-name,cid,98572181" xmltv_id="POLSAT Sport Premium 3">POLSAT Sport Premium 3</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-4,page,pl-name,cid,98572236" xmltv_id="POLSAT Sport Premium 4">POLSAT Sport Premium 4</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-5,page,pl-name,cid,98572289" xmltv_id="POLSAT Sport Premium 5">POLSAT Sport Premium 5</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-6,page,pl-name,cid,98572342" xmltv_id="POLSAT Sport Premium 6">POLSAT Sport Premium 6</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-explorer,page,pl-name,cid,20893044" xmltv_id="POLSAT Viasat Explorer">POLSAT Viasat Explorer</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-history,page,pl-name,cid,20887748" xmltv_id="POLSAT Viasat History">POLSAT Viasat History</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-history,page,pl-name,cid,21553074" xmltv_id="Polsat Viasat History">Polsat Viasat History</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-nature,page,pl-name,cid,20859999" xmltv_id="POLSAT Viasat Nature">POLSAT Viasat Nature</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polskie-radio-program-1,page,pl-name,cid,20868051" xmltv_id="Polskie Radio Program 1">Polskie Radio Program 1</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-polskie-radio-program-2,page,pl-name,cid,20868346" xmltv_id="Polskie Radio Program 2">Polskie Radio Program 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-power-tv,page,pl-name,cid,43722318" xmltv_id="Power TV">Power TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-power-tv-hd,page,pl-name,cid,43745091" xmltv_id="Power TV HD">Power TV HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-puls-2,page,pl-name,cid,31320163" xmltv_id="PULS 2">PULS 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-redlight-hd,page,pl-name,cid,31269443" xmltv_id="Redlight HD">Redlight HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-romance-tv,page,pl-name,cid,20912467" xmltv_id="Romance TV">Romance TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-romance-tv-hd,page,pl-name,cid,24057621" xmltv_id="Romance TV HD">Romance TV HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-russia-today-hd,page,pl-name,cid,41120816" xmltv_id="Russia Today HD">Russia Today HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-sci-fi,page,pl-name,cid,20893632" xmltv_id="SCI FI">SCI FI</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-sportklub,page,pl-name,cid,20878768" xmltv_id="SportKlub">SportKlub</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-stars-tv,page,pl-name,cid,34036918" xmltv_id="STARS.TV">STARS.TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-stopklatka-hd,page,pl-name,cid,46892507" xmltv_id="Stopklatka HD">Stopklatka HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-stopklatka-tv,page,pl-name,cid,46892480" xmltv_id="Stopklatka TV">Stopklatka TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-sundance-tv,page,pl-name,cid,20924643" xmltv_id="Sundance TV">Sundance TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-sundance-tv-hd,page,pl-name,cid,20856642" xmltv_id="Sundance TV HD">Sundance TV HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-super-polsat,page,pl-name,cid,78151147" xmltv_id="Super Polsat">Super Polsat</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-super-polsat-hd,page,pl-name,cid,83051206" xmltv_id="Super Polsat HD">Super Polsat HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-superstacja,page,pl-name,cid,20884198" xmltv_id="Superstacja">Superstacja</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tele-5,page,pl-name,cid,20837306" xmltv_id="Tele 5">Tele 5</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tele-5-hd,page,pl-name,cid,34036203" xmltv_id="Tele 5 HD">Tele 5 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-teletoon,page,pl-name,cid,20916997" xmltv_id="teleTOON+">teleTOON+</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-teletoon-hd,page,pl-name,cid,25685099" xmltv_id="teleTOON+HD">teleTOON+HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-telewizja-pomerania,page,pl-name,cid,41215329" xmltv_id="Telewizja Pomerania">Telewizja Pomerania</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tlc,page,pl-name,cid,20918901" xmltv_id="TLC">TLC</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tlc-hd,page,pl-name,cid,37483578" xmltv_id="TLC HD">TLC HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tnt,page,pl-name,cid,20887244" xmltv_id="TNT">TNT</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tnt-hd,page,pl-name,cid,64474084" xmltv_id="TNT HD">TNT HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-to-tv,page,pl-name,cid,20895991" xmltv_id="TO!TV">TO!TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-toya,page,pl-name,cid,20870562" xmltv_id="Toya">Toya</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-travel-channel,page,pl-name,cid,20913800" xmltv_id="Travel Channel">Travel Channel</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-travel-channel-hd,page,pl-name,cid,33720717" xmltv_id="Travel Channel HD">Travel Channel HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-ttv,page,pl-name,cid,90641308" xmltv_id="TTV">TTV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-ttv-hd,page,pl-name,cid,26671916" xmltv_id="TTV HD">TTV HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-4,page,pl-name,cid,20849296" xmltv_id="TV 4">TV 4</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-6,page,pl-name,cid,21912981" xmltv_id="TV 6">TV 6</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-puls,page,pl-name,cid,20829567" xmltv_id="TV Puls">TV Puls</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-puls-hd,page,pl-name,cid,52265531" xmltv_id="TV Puls HD">TV Puls HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-republika,page,pl-name,cid,38239036" xmltv_id="TV Republika">TV Republika</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-republika-hd,page,pl-name,cid,41731557" xmltv_id="TV Republika HD">TV Republika HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-trwam,page,pl-name,cid,20902892" xmltv_id="TV Trwam">TV Trwam</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn,page,pl-name,cid,20839130" xmltv_id="TVN">TVN</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-24,page,pl-name,cid,20833746" xmltv_id="TVN 24">TVN 24</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-24-biznes-i-swiat,page,pl-name,cid,20890054" xmltv_id="TVN 24 Biznes i Świat">TVN 24 Biznes i Świat</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-24-hd,page,pl-name,cid,34582198" xmltv_id="TVN 24 HD">TVN 24 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-7,page,pl-name,cid,20826216" xmltv_id="TVN 7">TVN 7</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-7-hd,page,pl-name,cid,25561446" xmltv_id="TVN 7 HD">TVN 7 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-fabula,page,pl-name,cid,59147597" xmltv_id="TVN Fabuła">TVN Fabuła</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-hd,page,pl-name,cid,20900412" xmltv_id="TVN HD">TVN HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-meteo-active,page,pl-name,cid,20888840" xmltv_id="TVN Meteo Active">TVN Meteo Active</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-style,page,pl-name,cid,20871227" xmltv_id="TVN Style">TVN Style</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-style-hd,page,pl-name,cid,25561006" xmltv_id="TVN Style HD">TVN Style HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-turbo,page,pl-name,cid,20832896" xmltv_id="TVN Turbo">TVN Turbo</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-turbo-hd,page,pl-name,cid,25561663" xmltv_id="TVN Turbo HD">TVN Turbo HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-1,page,pl-name,cid,20823112" xmltv_id="TVP 1">TVP 1</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-1-hd,page,pl-name,cid,21871081" xmltv_id="TVP 1 HD">TVP 1 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-2,page,pl-name,cid,20825004" xmltv_id="TVP 2">TVP 2</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-2-hd,page,pl-name,cid,30508107" xmltv_id="TVP 2 HD">TVP 2 HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3,page,pl-name,cid,41212710" xmltv_id="TVP 3">TVP 3</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-bialystok,page,pl-name,cid,20851594" xmltv_id="TVP 3 Białystok">TVP 3 Białystok</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-bydgoszcz,page,pl-name,cid,20853801" xmltv_id="TVP 3 Bydgoszcz">TVP 3 Bydgoszcz</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-gdansk,page,pl-name,cid,20856531" xmltv_id="TVP 3 Gdańsk">TVP 3 Gdańsk</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-gorzow-wielkopolski,page,pl-name,cid,20830895" xmltv_id="TVP 3 Gorzów Wielkopolski">TVP 3 Gorzów Wielkopolski</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-katowice,page,pl-name,cid,20858224" xmltv_id="TVP 3 Katowice">TVP 3 Katowice</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-kielce,page,pl-name,cid,20875146" xmltv_id="TVP 3 Kielce">TVP 3 Kielce</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-krakow,page,pl-name,cid,20860228" xmltv_id="TVP 3 Kraków">TVP 3 Kraków</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-lublin,page,pl-name,cid,20861847" xmltv_id="TVP 3 Lublin">TVP 3 Lublin</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-lodz,page,pl-name,cid,20863588" xmltv_id="TVP 3 Łódź">TVP 3 Łódź</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-olsztyn,page,pl-name,cid,20830631" xmltv_id="TVP 3 Olsztyn">TVP 3 Olsztyn</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-opole,page,pl-name,cid,20828344" xmltv_id="TVP 3 Opole">TVP 3 Opole</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-poznan,page,pl-name,cid,20864244" xmltv_id="TVP 3 Poznań">TVP 3 Poznań</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-rzeszow,page,pl-name,cid,20865381" xmltv_id="TVP 3 Rzeszów">TVP 3 Rzeszów</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-szczecin,page,pl-name,cid,20866287" xmltv_id="TVP 3 Szczecin">TVP 3 Szczecin</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-warszawa,page,pl-name,cid,20867178" xmltv_id="TVP 3 Warszawa">TVP 3 Warszawa</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-wroclaw,page,pl-name,cid,20867932" xmltv_id="TVP 3 Wrocław">TVP 3 Wrocław</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-abc,page,pl-name,cid,46047273" xmltv_id="TVP ABC">TVP ABC</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-hd,page,pl-name,cid,20901331" xmltv_id="TVP HD">TVP HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-historia,page,pl-name,cid,20887949" xmltv_id="TVP Historia">TVP Historia</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-info,page,pl-name,cid,20869425" xmltv_id="TVP Info">TVP Info</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-kultura,page,pl-name,cid,20873589" xmltv_id="TVP Kultura">TVP Kultura</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-polonia,page,pl-name,cid,20824511" xmltv_id="TVP Polonia">TVP Polonia</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-rozrywka,page,pl-name,cid,37578864" xmltv_id="TVP Rozrywka">TVP Rozrywka</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-seriale,page,pl-name,cid,20912238" xmltv_id="TVP Seriale">TVP Seriale</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-sport,page,pl-name,cid,20882463" xmltv_id="TVP Sport">TVP Sport</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-sport-hd,page,pl-name,cid,45143351" xmltv_id="TVP Sport HD">TVP Sport HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvr,page,pl-name,cid,20912765" xmltv_id="TVR">TVR</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvs,page,pl-name,cid,20895535" xmltv_id="TVS">TVS</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvs-hd,page,pl-name,cid,20902891" xmltv_id="TVS HD">TVS HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-twoja-telewizja-morska,page,pl-name,cid,21610155" xmltv_id="Twoja Telewizja Morska">Twoja Telewizja Morska</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-vox-music-tv,page,pl-name,cid,48652724" xmltv_id="VOX Music TV">VOX Music TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-water-planet-hd,page,pl-name,cid,34350167" xmltv_id="Water Planet HD">Water Planet HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-wp,page,pl-name,cid,77076434" xmltv_id="WP">WP</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-wp-hd,page,pl-name,cid,77076448" xmltv_id="WP HD">WP HD</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-wtk,page,pl-name,cid,20883344" xmltv_id="WTK">WTK</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-zest-tv,page,pl-name,cid,45232488" xmltv_id="Zest TV">Zest TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-zoom-tv,page,pl-name,cid,75975552" xmltv_id="Zoom TV">Zoom TV</channel>
-    <channel update="i" site="programtv.interia.pl" site_id="stacja-zoom-tv-hd,page,pl-name,cid,76115458" xmltv_id="Zoom TV HD">Zoom TV HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-13-ulica,cid,20915229" xmltv_id="13 Ulica">13 Ulica</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-13-ulica-hd,cid,69033907" xmltv_id="13 Ulica HD">13 Ulica HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-4fun-fitanddance,cid,24842601" xmltv_id="4FUN FIT&amp;DANCE">4FUN FIT&amp;DANCE</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-4fun-hits,cid,20909115" xmltv_id="4FUN HITS">4FUN HITS</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-4fun-tv,cid,20872501" xmltv_id="4FUN.TV">4FUN.TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-adventure,cid,52460227" xmltv_id="Adventure">Adventure</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-adventure-hd,cid,52460504" xmltv_id="Adventure HD">Adventure HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-ale-kino,cid,20916850" xmltv_id="Ale kino+">Ale kino+</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-ale-kino-hd,cid,25684497" xmltv_id="Ale kino+ HD">Ale kino+ HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-amc,cid,20883217" xmltv_id="AMC">AMC</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-animal-planet,cid,20907854" xmltv_id="Animal Planet">Animal Planet</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-atm-rozrywka,cid,30923643" xmltv_id="ATM Rozrywka">ATM Rozrywka</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn,cid,20833227" xmltv_id="AXN">AXN</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-black,cid,20878566" xmltv_id="AXN Black">AXN Black</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-hd,cid,20911492" xmltv_id="AXN HD">AXN HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-spin,cid,27148909" xmltv_id="AXN Spin">AXN Spin</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-spin-hd,cid,45367726" xmltv_id="AXN Spin HD">AXN Spin HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-axn-white,cid,20878407" xmltv_id="AXN White">AXN White</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-baby-tv,cid,20909214" xmltv_id="Baby TV">Baby TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-babyfirsttv,cid,20906031" xmltv_id="BabyFirstTV">BabyFirstTV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-brit,cid,20892106" xmltv_id="BBC Brit">BBC Brit</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-cbeebies,cid,20892336" xmltv_id="BBC CBeebies">BBC CBeebies</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-earth,cid,20893043" xmltv_id="BBC Earth">BBC Earth</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-hd,cid,20859632" xmltv_id="BBC HD">BBC HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-knowledge-hd,cid,20863712" xmltv_id="BBC Knowledge HD">BBC Knowledge HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-bbc-lifestyle,cid,20893216" xmltv_id="BBC Lifestyle">BBC Lifestyle</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-boomerang,cid,20875977" xmltv_id="Boomerang">Boomerang</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal,cid,20832249" xmltv_id="CANAL+">CANAL+</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-discovery,cid,59830186" xmltv_id="CANAL+ Discovery">CANAL+ Discovery</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-discovery-hd,cid,59864094" xmltv_id="CANAL+ Discovery HD">CANAL+ Discovery HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-family,cid,37499941" xmltv_id="CANAL+ Family">CANAL+ Family</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-family-hd,cid,37500465" xmltv_id="CANAL+ Family HD">CANAL+ Family HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-film,cid,20916995" xmltv_id="CANAL+ Film">CANAL+ Film</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-film-hd,cid,20899951" xmltv_id="CANAL+ Film HD">CANAL+ Film HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-hd,cid,20913424" xmltv_id="CANAL+ HD">CANAL+ HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-seriale,cid,37499682" xmltv_id="CANAL+ Seriale">CANAL+ Seriale</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-seriale-hd,cid,37500989" xmltv_id="CANAL+ Seriale HD">CANAL+ Seriale HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport,cid,20916996" xmltv_id="CANAL+ Sport">CANAL+ Sport</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport-2,cid,59587547" xmltv_id="CANAL+ Sport 2">CANAL+ Sport 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport-2-hd,cid,59864427" xmltv_id="CANAL+ Sport 2 HD">CANAL+ Sport 2 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-sport-hd,cid,20900147" xmltv_id="CANAL+ Sport HD">CANAL+ Sport HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-1,cid,37500201" xmltv_id="CANAL+1">CANAL+1</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-canal-1-hd,cid,37500725" xmltv_id="CANAL+1 HD">CANAL+1 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-cartoon-network,cid,20886775" xmltv_id="Cartoon Network">Cartoon Network</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-cbs-europa,cid,20915866" xmltv_id="CBS Europa">CBS Europa</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-cbs-reality,cid,20916555" xmltv_id="CBS Reality">CBS Reality</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-ci-polsat,cid,20838196" xmltv_id="CI POLSAT">CI POLSAT</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax,cid,20879298" xmltv_id="Cinemax">Cinemax</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax-2,cid,20876522" xmltv_id="Cinemax 2">Cinemax 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax-2-hd,cid,20913423" xmltv_id="Cinemax 2 HD">Cinemax 2 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-cinemax-hd,cid,20859862" xmltv_id="Cinemax HD">Cinemax HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-comedy-central,cid,20879299" xmltv_id="Comedy Central">Comedy Central</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-comedy-central-family,cid,20876656" xmltv_id="Comedy Central Family">Comedy Central Family</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-csb-tv,cid,20911757" xmltv_id="CSB TV">CSB TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-czworka-polskie-radio,cid,20913114" xmltv_id="Czwórka Polskie Radio">Czwórka Polskie Radio</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-da-vinci,cid,20891002" xmltv_id="Da Vinci">Da Vinci</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-disco-polo-music,cid,48623077" xmltv_id="Disco Polo Music">Disco Polo Music</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-channel,cid,20914054" xmltv_id="Discovery Channel">Discovery Channel</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-channel-hd,cid,20882598" xmltv_id="Discovery Channel HD">Discovery Channel HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-historia,cid,20882858" xmltv_id="Discovery Historia">Discovery Historia</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-life,cid,20913506" xmltv_id="Discovery Life">Discovery Life</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-science,cid,20919134" xmltv_id="Discovery Science">Discovery Science</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-turbo-xtra,cid,20919399" xmltv_id="Discovery Turbo Xtra">Discovery Turbo Xtra</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-discovery-turbo-xtra-hd,cid,47963140" xmltv_id="Discovery Turbo Xtra HD">Discovery Turbo Xtra HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-disney-channel,cid,20874161" xmltv_id="Disney Channel">Disney Channel</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-disney-junior,cid,20873088" xmltv_id="Disney Junior">Disney Junior</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-disney-xd,cid,20914870" xmltv_id="Disney XD">Disney XD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-dlaciebie-tv,cid,31692370" xmltv_id="dlaCiebie.tv">dlaCiebie.tv</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-docubox-hd,cid,43362279" xmltv_id="DocuBox HD">DocuBox HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-domo,cid,20901927" xmltv_id="Domo+">Domo+</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-domo-hd,cid,25684984" xmltv_id="Domo+ HD">Domo+ HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-duck-tv,cid,20896315" xmltv_id="Duck TV">Duck TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-duck-tv-hd,cid,34036627" xmltv_id="Duck TV HD">Duck TV HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-e-entertaiment-hd,cid,41121255" xmltv_id="E! Entertaiment HD">E! Entertaiment HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-e-entertainment,cid,20887377" xmltv_id="E! Entertainment">E! Entertainment</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-edusat,cid,20872729" xmltv_id="Edusat">Edusat</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-edusat-hd,cid,34358070" xmltv_id="Edusat HD">Edusat HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-1,cid,63020620" xmltv_id="Eleven Sports 1">Eleven Sports 1</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-1-hd,cid,67360876" xmltv_id="Eleven Sports 1 HD">Eleven Sports 1 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-2,cid,63029815" xmltv_id="Eleven Sports 2">Eleven Sports 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-2-hd,cid,67361119" xmltv_id="Eleven Sports 2 HD">Eleven Sports 2 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-3,cid,77007149" xmltv_id="Eleven Sports 3">Eleven Sports 3</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-3-hd,cid,77124853" xmltv_id="Eleven Sports 3 HD">Eleven Sports 3 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-4,cid,90643965" xmltv_id="Eleven Sports 4">Eleven Sports 4</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eleven-sports-4-hd,cid,94587855" xmltv_id="Eleven Sports 4 HD">Eleven Sports 4 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-english-club-tv,cid,31868352" xmltv_id="English Club TV">English Club TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eska-rock-tv,cid,70432907" xmltv_id="Eska Rock TV">Eska Rock TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eska-tv,cid,20906550" xmltv_id="Eska TV">Eska TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eska-tv-extra,cid,84225806" xmltv_id="Eska TV Extra">Eska TV Extra</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurochannel,cid,45447505" xmltv_id="Eurochannel">Eurochannel</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-1,cid,20900411" xmltv_id="Eurosport 1">Eurosport 1</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-1-hd,cid,20900276" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-2,cid,20890823" xmltv_id="Eurosport 2">Eurosport 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-eurosport-2-hd,cid,20908509" xmltv_id="Eurosport 2 HD">Eurosport 2 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-extreme,cid,20915601" xmltv_id="Extreme">Extreme</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-family-sport,cid,43062622" xmltv_id="Family Sport">Family Sport</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-family-sport-hd,cid,42949027" xmltv_id="Family Sport HD">Family Sport HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fashion-one,cid,33409784" xmltv_id="Fashion One">Fashion One</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fashion-one-hd,cid,34036349" xmltv_id="Fashion One HD">Fashion One HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fightbox-hd,cid,30660243" xmltv_id="FightBox HD">FightBox HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fightklub,cid,20888671" xmltv_id="FightKlub">FightKlub</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fightklub-hd,cid,41122509" xmltv_id="Fightklub HD">Fightklub HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox,cid,20891371" xmltv_id="Filmbox">Filmbox</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-action,cid,32750767" xmltv_id="FilmBox Action">FilmBox Action</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-arthouse,cid,45826521" xmltv_id="FilmBox Arthouse">FilmBox Arthouse</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-extra-hd,cid,20891963" xmltv_id="FilmBox Extra HD">FilmBox Extra HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-family,cid,20901645" xmltv_id="Filmbox Family">Filmbox Family</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-filmbox-premium,cid,20891825" xmltv_id="FilmBox Premium">FilmBox Premium</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fokus-tv,cid,48284912" xmltv_id="Fokus TV">Fokus TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox,cid,20911996" xmltv_id="FOX">FOX</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox-comedy,cid,20884527" xmltv_id="Fox Comedy">Fox Comedy</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox-comedy-hd,cid,20858786" xmltv_id="Fox Comedy HD">Fox Comedy HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-fox-hd,cid,20912237" xmltv_id="FOX HD">FOX HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-ginx-tv,cid,34743591" xmltv_id="GINX TV">GINX TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-golf-channel,cid,81067471" xmltv_id="Golf Channel">Golf Channel</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-golf-channel-hd,cid,81067720" xmltv_id="Golf Channel HD">Golf Channel HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-h2,cid,54186261" xmltv_id="H2">H2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-h2-hd,cid,54219062" xmltv_id="H2 HD">H2 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo,cid,20833599" xmltv_id="HBO">HBO</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo-hd,cid,20900275" xmltv_id="HBO HD">HBO HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo2,cid,20830747" xmltv_id="HBO2">HBO2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo2-hd,cid,20913421" xmltv_id="HBO2 HD">HBO2 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo3,cid,20886553" xmltv_id="HBO3">HBO3</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-hbo3-hd,cid,20913422" xmltv_id="HBO3 HD">HBO3 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-history,cid,20895304" xmltv_id="HISTORY">HISTORY</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-history-hd,cid,20895772" xmltv_id="HISTORY HD">HISTORY HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-id,cid,20906723" xmltv_id="ID">ID</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-id-hd,cid,47963109" xmltv_id="ID HD">ID HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-jimjam-polsat,cid,20893922" xmltv_id="JimJam Polsat">JimJam Polsat</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-kino-polska,cid,20825341" xmltv_id="Kino Polska">Kino Polska</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-kino-polska-muzyka,cid,21965593" xmltv_id="Kino Polska Muzyka">Kino Polska Muzyka</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-kuchnia,cid,20878933" xmltv_id="Kuchnia+">Kuchnia+</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-kuchnia-hd,cid,25684935" xmltv_id="Kuchnia+ HD">Kuchnia+ HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-lifetime,cid,55306381" xmltv_id="Lifetime">Lifetime</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-love,cid,20890188" xmltv_id="LOVE">LOVE</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-mango,cid,20904509" xmltv_id="Mango">Mango</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-metro,cid,77128432" xmltv_id="METRO">METRO</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-metro-hd,cid,77128511" xmltv_id="METRO HD">METRO HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-minimini,cid,20915980" xmltv_id="MiniMini+">MiniMini+</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-minimini-hd,cid,25685026" xmltv_id="MiniMini+ HD">MiniMini+ HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-mtv-music,cid,20918680" xmltv_id="MTV Music">MTV Music</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-mtv-polska,cid,20827512" xmltv_id="MTV Polska">MTV Polska</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nat-geo-people-hd,cid,63755427" xmltv_id="Nat Geo People HD">Nat Geo People HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nat-geo-wild,cid,20888462" xmltv_id="Nat Geo Wild">Nat Geo Wild</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nat-geo-wild-hd,cid,20908152" xmltv_id="Nat Geo Wild HD">Nat Geo Wild HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-national-geographic,cid,20915414" xmltv_id="National Geographic">National Geographic</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-national-geographic-hd,cid,20888256" xmltv_id="National Geographic HD">National Geographic HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nhk-world-tv,cid,33471159" xmltv_id="NHK World TV">NHK World TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nick-jr,cid,21492375" xmltv_id="Nick Jr.">Nick Jr.</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nickelodeon,cid,20900855" xmltv_id="Nickelodeon">Nickelodeon</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nickelodeon-hd,cid,24866540" xmltv_id="Nickelodeon HD">Nickelodeon HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-novela-tv,cid,31711335" xmltv_id="Novela tv">Novela tv</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-novela-tv-hd,cid,34330427" xmltv_id="Novela tv HD">Novela tv HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nowa-tv,cid,76305294" xmltv_id="Nowa TV">Nowa TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nowa-tv-hd,cid,76570733" xmltv_id="Nowa TV HD">Nowa TV HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nsport,cid,20883216" xmltv_id="nSport">nSport</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-nsport-hd,cid,20837937" xmltv_id="nSport HD">nSport HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-paramount-channel-hd,cid,23150731" xmltv_id="Paramount Channel HD">Paramount Channel HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-planete,cid,20836142" xmltv_id="Planete+">Planete+</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-planete-hd,cid,25684913" xmltv_id="PLANETE+ HD">PLANETE+ HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polo-tv,cid,22358930" xmltv_id="Polo TV">Polo TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polonia-1,cid,20826441" xmltv_id="Polonia 1">Polonia 1</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat,cid,20825644" xmltv_id="Polsat">Polsat</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-2,cid,20825920" xmltv_id="Polsat 2">Polsat 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-cafe,cid,20902523" xmltv_id="Polsat Café">Polsat Café</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-doku,cid,79468518" xmltv_id="POLSAT Doku">POLSAT Doku</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-doku-hd,cid,79583195" xmltv_id="POLSAT Doku HD">POLSAT Doku HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-film,cid,20908510" xmltv_id="Polsat Film">Polsat Film</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-film-hd,cid,35424992" xmltv_id="POLSAT Film HD">POLSAT Film HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-food,cid,34502467" xmltv_id="POLSAT Food">POLSAT Food</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-food-network-hd,cid,61052040" xmltv_id="POLSAT Food Network HD">POLSAT Food Network HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-hd,cid,20908413" xmltv_id="Polsat HD">Polsat HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-music-hd,cid,53371105" xmltv_id="Polsat Music HD">Polsat Music HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-news,cid,20900413" xmltv_id="Polsat News">Polsat News</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-news-2,cid,20871594" xmltv_id="Polsat News 2">Polsat News 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-news-hd,cid,45873361" xmltv_id="POLSAT News HD">POLSAT News HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-play,cid,20902237" xmltv_id="Polsat Play">Polsat Play</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-romans,cid,41377056" xmltv_id="POLSAT Romans">POLSAT Romans</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport,cid,20829758" xmltv_id="Polsat Sport">Polsat Sport</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-extra,cid,20876428" xmltv_id="Polsat Sport Extra">Polsat Sport Extra</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-extra-hd,cid,30542018" xmltv_id="Polsat Sport Extra HD">Polsat Sport Extra HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-fight-hd,cid,73401252" xmltv_id="Polsat Sport Fight HD">Polsat Sport Fight HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-hd,cid,20899857" xmltv_id="Polsat Sport HD">Polsat Sport HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-news,cid,21985309" xmltv_id="Polsat Sport News">Polsat Sport News</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-1,cid,98571860" xmltv_id="POLSAT Sport Premium 1">POLSAT Sport Premium 1</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-2,cid,98572021" xmltv_id="POLSAT Sport Premium 2">POLSAT Sport Premium 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-3,cid,98572181" xmltv_id="POLSAT Sport Premium 3">POLSAT Sport Premium 3</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-4,cid,98572236" xmltv_id="POLSAT Sport Premium 4">POLSAT Sport Premium 4</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-5,cid,98572289" xmltv_id="POLSAT Sport Premium 5">POLSAT Sport Premium 5</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-sport-premium-6,cid,98572342" xmltv_id="POLSAT Sport Premium 6">POLSAT Sport Premium 6</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-explorer,cid,20893044" xmltv_id="POLSAT Viasat Explorer">POLSAT Viasat Explorer</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-history,cid,20887748" xmltv_id="POLSAT Viasat History">POLSAT Viasat History</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-history,cid,21553074" xmltv_id="Polsat Viasat History">Polsat Viasat History</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polsat-viasat-nature,cid,20859999" xmltv_id="POLSAT Viasat Nature">POLSAT Viasat Nature</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polskie-radio-program-1,cid,20868051" xmltv_id="Polskie Radio Program 1">Polskie Radio Program 1</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-polskie-radio-program-2,cid,20868346" xmltv_id="Polskie Radio Program 2">Polskie Radio Program 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-power-tv,cid,43722318" xmltv_id="Power TV">Power TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-power-tv-hd,cid,43745091" xmltv_id="Power TV HD">Power TV HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-puls-2,cid,31320163" xmltv_id="PULS 2">PULS 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-redlight-hd,cid,31269443" xmltv_id="Redlight HD">Redlight HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-romance-tv,cid,20912467" xmltv_id="Romance TV">Romance TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-romance-tv-hd,cid,24057621" xmltv_id="Romance TV HD">Romance TV HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-russia-today-hd,cid,41120816" xmltv_id="Russia Today HD">Russia Today HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-sci-fi,cid,20893632" xmltv_id="SCI FI">SCI FI</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-sportklub,cid,20878768" xmltv_id="SportKlub">SportKlub</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-stars-tv,cid,34036918" xmltv_id="STARS.TV">STARS.TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-stopklatka-hd,cid,46892507" xmltv_id="Stopklatka HD">Stopklatka HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-stopklatka-tv,cid,46892480" xmltv_id="Stopklatka TV">Stopklatka TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-sundance-tv,cid,20924643" xmltv_id="Sundance TV">Sundance TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-sundance-tv-hd,cid,20856642" xmltv_id="Sundance TV HD">Sundance TV HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-super-polsat,cid,78151147" xmltv_id="Super Polsat">Super Polsat</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-super-polsat-hd,cid,83051206" xmltv_id="Super Polsat HD">Super Polsat HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-superstacja,cid,20884198" xmltv_id="Superstacja">Superstacja</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tele-5,cid,20837306" xmltv_id="Tele 5">Tele 5</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tele-5-hd,cid,34036203" xmltv_id="Tele 5 HD">Tele 5 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-teletoon,cid,20916997" xmltv_id="teleTOON+">teleTOON+</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-teletoon-hd,cid,25685099" xmltv_id="teleTOON+HD">teleTOON+HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-telewizja-pomerania,cid,41215329" xmltv_id="Telewizja Pomerania">Telewizja Pomerania</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tlc,cid,20918901" xmltv_id="TLC">TLC</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tlc-hd,cid,37483578" xmltv_id="TLC HD">TLC HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tnt,cid,20887244" xmltv_id="TNT">TNT</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tnt-hd,cid,64474084" xmltv_id="TNT HD">TNT HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-to-tv,cid,20895991" xmltv_id="TO!TV">TO!TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-toya,cid,20870562" xmltv_id="Toya">Toya</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-travel-channel,cid,20913800" xmltv_id="Travel Channel">Travel Channel</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-travel-channel-hd,cid,33720717" xmltv_id="Travel Channel HD">Travel Channel HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-ttv,cid,90641308" xmltv_id="TTV">TTV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-ttv-hd,cid,26671916" xmltv_id="TTV HD">TTV HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-4,cid,20849296" xmltv_id="TV 4">TV 4</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-6,cid,21912981" xmltv_id="TV 6">TV 6</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-puls,cid,20829567" xmltv_id="TV Puls">TV Puls</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-puls-hd,cid,52265531" xmltv_id="TV Puls HD">TV Puls HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-republika,cid,38239036" xmltv_id="TV Republika">TV Republika</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-republika-hd,cid,41731557" xmltv_id="TV Republika HD">TV Republika HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tv-trwam,cid,20902892" xmltv_id="TV Trwam">TV Trwam</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn,cid,20839130" xmltv_id="TVN">TVN</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-24,cid,20833746" xmltv_id="TVN 24">TVN 24</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-24-biznes-i-swiat,cid,20890054" xmltv_id="TVN 24 Biznes i Świat">TVN 24 Biznes i Świat</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-24-hd,cid,34582198" xmltv_id="TVN 24 HD">TVN 24 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-7,cid,20826216" xmltv_id="TVN 7">TVN 7</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-7-hd,cid,25561446" xmltv_id="TVN 7 HD">TVN 7 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-fabula,cid,59147597" xmltv_id="TVN Fabuła">TVN Fabuła</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-hd,cid,20900412" xmltv_id="TVN HD">TVN HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-meteo-active,cid,20888840" xmltv_id="TVN Meteo Active">TVN Meteo Active</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-style,cid,20871227" xmltv_id="TVN Style">TVN Style</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-style-hd,cid,25561006" xmltv_id="TVN Style HD">TVN Style HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-turbo,cid,20832896" xmltv_id="TVN Turbo">TVN Turbo</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvn-turbo-hd,cid,25561663" xmltv_id="TVN Turbo HD">TVN Turbo HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-1,cid,20823112" xmltv_id="TVP 1">TVP 1</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-1-hd,cid,21871081" xmltv_id="TVP 1 HD">TVP 1 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-2,cid,20825004" xmltv_id="TVP 2">TVP 2</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-2-hd,cid,30508107" xmltv_id="TVP 2 HD">TVP 2 HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3,cid,41212710" xmltv_id="TVP 3">TVP 3</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-bialystok,cid,20851594" xmltv_id="TVP 3 Białystok">TVP 3 Białystok</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-bydgoszcz,cid,20853801" xmltv_id="TVP 3 Bydgoszcz">TVP 3 Bydgoszcz</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-gdansk,cid,20856531" xmltv_id="TVP 3 Gdańsk">TVP 3 Gdańsk</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-gorzow-wielkopolski,cid,20830895" xmltv_id="TVP 3 Gorzów Wielkopolski">TVP 3 Gorzów Wielkopolski</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-katowice,cid,20858224" xmltv_id="TVP 3 Katowice">TVP 3 Katowice</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-kielce,cid,20875146" xmltv_id="TVP 3 Kielce">TVP 3 Kielce</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-krakow,cid,20860228" xmltv_id="TVP 3 Kraków">TVP 3 Kraków</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-lublin,cid,20861847" xmltv_id="TVP 3 Lublin">TVP 3 Lublin</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-lodz,cid,20863588" xmltv_id="TVP 3 Łódź">TVP 3 Łódź</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-olsztyn,cid,20830631" xmltv_id="TVP 3 Olsztyn">TVP 3 Olsztyn</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-opole,cid,20828344" xmltv_id="TVP 3 Opole">TVP 3 Opole</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-poznan,cid,20864244" xmltv_id="TVP 3 Poznań">TVP 3 Poznań</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-rzeszow,cid,20865381" xmltv_id="TVP 3 Rzeszów">TVP 3 Rzeszów</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-szczecin,cid,20866287" xmltv_id="TVP 3 Szczecin">TVP 3 Szczecin</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-warszawa,cid,20867178" xmltv_id="TVP 3 Warszawa">TVP 3 Warszawa</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-3-wroclaw,cid,20867932" xmltv_id="TVP 3 Wrocław">TVP 3 Wrocław</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-abc,cid,46047273" xmltv_id="TVP ABC">TVP ABC</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-hd,cid,20901331" xmltv_id="TVP HD">TVP HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-historia,cid,20887949" xmltv_id="TVP Historia">TVP Historia</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-info,cid,20869425" xmltv_id="TVP Info">TVP Info</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-kultura,cid,20873589" xmltv_id="TVP Kultura">TVP Kultura</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-polonia,cid,20824511" xmltv_id="TVP Polonia">TVP Polonia</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-rozrywka,cid,37578864" xmltv_id="TVP Rozrywka">TVP Rozrywka</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-seriale,cid,20912238" xmltv_id="TVP Seriale">TVP Seriale</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-sport,cid,20882463" xmltv_id="TVP Sport">TVP Sport</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvp-sport-hd,cid,45143351" xmltv_id="TVP Sport HD">TVP Sport HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvr,cid,20912765" xmltv_id="TVR">TVR</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvs,cid,20895535" xmltv_id="TVS">TVS</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-tvs-hd,cid,20902891" xmltv_id="TVS HD">TVS HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-twoja-telewizja-morska,cid,21610155" xmltv_id="Twoja Telewizja Morska">Twoja Telewizja Morska</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-vox-music-tv,cid,48652724" xmltv_id="VOX Music TV">VOX Music TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-water-planet-hd,cid,34350167" xmltv_id="Water Planet HD">Water Planet HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-wp,cid,77076434" xmltv_id="WP">WP</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-wp-hd,cid,77076448" xmltv_id="WP HD">WP HD</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-wtk,cid,20883344" xmltv_id="WTK">WTK</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-zest-tv,cid,45232488" xmltv_id="Zest TV">Zest TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-zoom-tv,cid,75975552" xmltv_id="Zoom TV">Zoom TV</channel>
+    <channel update="i" site="programtv.interia.pl" site_id="stacja-zoom-tv-hd,cid,76115458" xmltv_id="Zoom TV HD">Zoom TV HD</channel>
   </channels>
 </site>

--- a/siteini.pack/Poland/programtv.interia.pl.ini
+++ b/siteini.pack/Poland/programtv.interia.pl.ini
@@ -8,6 +8,7 @@
 *   - Fixed channel file creation mode
 *   - Refined rating
 *   - Changed max days to 13
+*   - Changed to https
 * @Revision 7 - [05/09/2018] Mr Groch
 *   - Fixed category dividing
 *   - Fixed wrong country when no country provided
@@ -34,15 +35,15 @@ site {ratingsystem=PL}
 site {episodesystem=onscreen} *Enable for Onscreen Episode System
 *site {episodesystem=xmltv_ns} *Enable for xmltv_ns Episode System
 *
-url_index{url|http://programtv.interia.pl/stacja-|channel|,o,|urldate}
+url_index{url|https://programtv.interia.pl/stacja-|channel|,o,|urldate}
 urldate.format {daycounter|0}
 *
 index_showsplit.scrub {multi|<div class="tv-content">|<div class="item-wrap">||<div class="print-indicator">}
 index_start.scrub {single|<div class="emission-time">||<|</div>}
 index_title.scrub {single|<div class="emission-name">|title="|">|</a>}
 index_category.scrub {regex||<span class="cat-container">(.*?)</span>||}
-index_urlshow {url|http://programtv.interia.pl|<a href="||"|</a>}
-*http://programtv.interia.pl/audycja-polska-wedlug-kreta,aid,31979410
+index_urlshow {url|https://programtv.interia.pl|<a href="||"|</a>}
+*https://programtv.interia.pl/audycja-polska-wedlug-kreta,aid,31979410
 index_urlchannellogo   {url ||<div class="img">| src="|"|</div>}
 
 index_category.modify {remove(type=regex)|<[^>]*>}
@@ -105,18 +106,18 @@ category.modify {cleanup}
 *category.modify {remove(type=regex)|:$}
 
 * show info in description header
-*temp_3.modify {addstart('starrating' not"")|##'starrating'}
-*temp_3.modify {addstart('rating' not"")|##'rating'}
-*temp_3.modify {addstart('productiondate' not"")|##'productiondate'}
-*temp_3.modify {addstart(separator="/" 'country' not"")|##'country'}
-*temp_3.modify {replace()|##| ¤ }
-*description.modify {addstart('temp_3' not"")|'temp_3'\n}
+temp_3.modify {addstart('starrating' not"")|##'starrating'}
+temp_3.modify {addstart('rating' not"")|##'rating'}
+temp_3.modify {addstart('productiondate' not"")|##'productiondate'}
+temp_3.modify {addstart(separator="/" 'country' not"")|##'country'}
+temp_3.modify {replace()|##| ¤ }
+description.modify {addstart('temp_3' not"")|'temp_3'\n}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
 **
 ** @auto_xml_channel_start
-*url_index{url|http://programtv.interia.pl/lista-stacji}
+*url_index{url|https://programtv.interia.pl/lista-stacji}
 *index_site_id.scrub {multi|                         <a href="/stacja||" title=|</a>}
 *index_site_channel.scrub {multi|                         <a href="/stacja|title="|">|</a>}
 *index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}

--- a/siteini.pack/Poland/programtv.interia.pl.ini
+++ b/siteini.pack/Poland/programtv.interia.pl.ini
@@ -106,12 +106,12 @@ category.modify {cleanup}
 *category.modify {remove(type=regex)|:$}
 
 * show info in description header
-temp_3.modify {addstart('starrating' not"")|##'starrating'}
-temp_3.modify {addstart('rating' not"")|##'rating'}
-temp_3.modify {addstart('productiondate' not"")|##'productiondate'}
-temp_3.modify {addstart(separator="/" 'country' not"")|##'country'}
-temp_3.modify {replace()|##| ¤ }
-description.modify {addstart('temp_3' not"")|'temp_3'\n}
+*temp_3.modify {addstart('starrating' not"")|##'starrating'}
+*temp_3.modify {addstart('rating' not"")|##'rating'}
+*temp_3.modify {addstart('productiondate' not"")|##'productiondate'}
+*temp_3.modify {addstart(separator="/" 'country' not"")|##'country'}
+*temp_3.modify {replace()|##| ¤ }
+*description.modify {addstart('temp_3' not"")|'temp_3'\n}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)

--- a/siteini.pack/Poland/programtv.interia.pl.ini
+++ b/siteini.pack/Poland/programtv.interia.pl.ini
@@ -2,8 +2,12 @@
 * @header_start
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: programtv.interia.pl
-* @MinSWversion: V1.1.1/54
-*   none
+* @MinSWversion: V2.1
+* @Revision 8 - [19/01/2020] Mr Groch
+*   - Fixed country info seperated list in description
+*   - Fixed channel file creation mode
+*   - Refined rating
+*   - Changed max days to 13
 * @Revision 7 - [05/09/2018] Mr Groch
 *   - Fixed category dividing
 *   - Fixed wrong country when no country provided
@@ -21,11 +25,11 @@
 * @Revision 3 - [20/08/2012] Willy de Wilde/Jan van Straaten
 *   complete new (site change)
 * @Remarks:
-*   none
 * @header_end
 **------------------------------------------------------------------------------------------------
 
-site {url=programtv.interia.pl|timezone=Europe/Warsaw|maxdays=10|cultureinfo=pl-PL|charset=utf-8|titlematchfactor=50}
+site {url=programtv.interia.pl|timezone=Europe/Warsaw|maxdays=13|cultureinfo=pl-PL|charset=utf-8|titlematchfactor=90}
+site {ratingsystem=PL}
 *
 site {episodesystem=onscreen} *Enable for Onscreen Episode System
 *site {episodesystem=xmltv_ns} *Enable for xmltv_ns Episode System
@@ -82,7 +86,7 @@ writer.modify {cleanup}
 rating.scrub {single|<li class="info-item age">|<img class="tv-icon" src="/s/programmeTv/classic/ico/|" alt|</span>}
 rating.modify {replace(~ "age-0-")|'rating'|0+}
 rating.modify {replace(~ "age-1-")|'rating'|16+}
-rating.modify {replace(~ "age-2-")|'rating'|++O?}
+rating.modify {replace(~ "age-2-")|'rating'|18+}
 rating.modify {replace(~ "age-3-")|'rating'|7+}
 rating.modify {replace(~ "age-4-")|'rating'|12+}
 starrating.scrub {single|<div class="info-item rating">|alt="ocena |"/>|</div>}
@@ -101,26 +105,20 @@ category.modify {cleanup}
 *category.modify {remove(type=regex)|:$}
 
 * show info in description header
-*temp_3.modify {addstart('starrating' not"")| ¤ 'starrating'}
-*temp_3.modify {addstart('rating' not"")| ¤ 'rating'}
-*temp_3.modify {addstart('productiondate' not"")| ¤ 'productiondate'}
-*loop {(each "temp_4" in 'country' max=10)|end}
-*temp_3.modify {addstart('temp_4' not"")|'temp_4'}
-*temp_5.modify {calculate('temp_4' not"" type=element format=F0)|'country' #}
-*temp_6.modify {calculate('temp_4' not"" type=element format=F0)|'country' 'temp_4' @}
-*temp_6.modify {calculate('temp_4' not"" format=F0)|1 +}
-*temp_3.modify {addstart('temp_5' not= 'temp_6')|/}
-*end_loop
-*temp_3.modify {addstart('temp_4' not"")|¤ }
+*temp_3.modify {addstart('starrating' not"")|##'starrating'}
+*temp_3.modify {addstart('rating' not"")|##'rating'}
+*temp_3.modify {addstart('productiondate' not"")|##'productiondate'}
+*temp_3.modify {addstart(separator="/" 'country' not"")|##'country'}
+*temp_3.modify {replace()|##| ¤ }
 *description.modify {addstart('temp_3' not"")|'temp_3'\n}
-
+*
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
 **
 ** @auto_xml_channel_start
+*url_index{url|http://programtv.interia.pl/lista-stacji}
 *index_site_id.scrub {multi|                         <a href="/stacja||" title=|</a>}
 *index_site_channel.scrub {multi|                         <a href="/stacja|title="|">|</a>}
 *index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}
 *index_site_id.modify {addstart|stacja}
-*end_scope
 ** @auto_xml_channel_end

--- a/siteini.pack/Poland/programtv.onet.pl.channels.xml
+++ b/siteini.pack/Poland/programtv.onet.pl.channels.xml
@@ -1,17 +1,20 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V1.56.24 -- Jan van Straaten" site="programtv.onet.pl">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.1.11.0 -- Jan van Straaten" site="programtv.onet.pl">
   <channels>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/13th-street-250" xmltv_id="13th Street">13th Street</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/13-tv-312" xmltv_id="13.tv">13.tv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/13-ulica-316" xmltv_id="13 Ulica">13 Ulica</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/13-ulica-hd-509" xmltv_id="13 Ulica HD">13 Ulica HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/2x2-604" xmltv_id="2x2">2x2</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/2x2-hd-613" xmltv_id="2x2 HD">2x2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/360tunebox-302" xmltv_id="360TuneBox">360TuneBox</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/360tunebox-hd-304" xmltv_id="360TuneBox HD">360TuneBox HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/3sat-248" xmltv_id="3SAT">3SAT</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/4fun-tv-269" xmltv_id="4FUN.TV">4FUN.TV</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/4fun-fit-dance-244" xmltv_id="4FUN FIT&amp;DANCE">4FUN FIT&amp;DANCE</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/4fun-hits-283" xmltv_id="4FUN HITS">4FUN HITS</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ab-moteurs-242" xmltv_id="AB Moteurs">AB Moteurs</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/4fun-fit-dance-244" xmltv_id="4FUN DANCE">4FUN DANCE</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/4fun-hits-283" xmltv_id="4FUN GOLD">4FUN GOLD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/8tv-523" xmltv_id="8TV">8TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/8tv-hd-524" xmltv_id="8TV HD">8TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/active-family-300" xmltv_id="Active Family">Active Family</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/active-family-hd-301" xmltv_id="Active Family HD">Active Family HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/adult-channel-265" xmltv_id="Adult Channel">Adult Channel</channel>
@@ -20,6 +23,7 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ale-kino-319" xmltv_id="Ale kino+">Ale kino+</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ale-kino-hd-262" xmltv_id="Ale kino+ HD">Ale kino+ HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/al-jazeera-31" xmltv_id="Al Jazeera">Al Jazeera</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/al-jazeera-hd-609" xmltv_id="Al Jazeera HD">Al Jazeera HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/amazing-tv-508" xmltv_id="Amazing TV">Amazing TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mgm-333" xmltv_id="AMC">AMC</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mgm-hd-68" xmltv_id="AMC HD">AMC HD</channel>
@@ -31,6 +35,7 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/arte-hd-290" xmltv_id="Arte HD">Arte HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/atm-rozrywka-287" xmltv_id="ATM Rozrywka">ATM Rozrywka</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/atv-251" xmltv_id="ATV">ATV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ab-moteurs-242" xmltv_id="Automoto la chaîne">Automoto la chaîne</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/axn-249" xmltv_id="AXN">AXN</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/axn-black-271" xmltv_id="AXN Black">AXN Black</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/axn-hd-286" xmltv_id="AXN HD">AXN HD</channel>
@@ -44,45 +49,54 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-cbeebies-2" xmltv_id="BBC CBeebies">BBC CBeebies</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-earth-274" xmltv_id="BBC Earth">BBC Earth</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-earth-hd-263" xmltv_id="BBC Earth HD">BBC Earth HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-hd-261" xmltv_id="BBC HD">BBC HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-hd-261" xmltv_id="BBC First">BBC First</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-lifestyle-277" xmltv_id="BBC Lifestyle">BBC Lifestyle</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-lifestyle-hd-542" xmltv_id="BBC Lifestyle HD">BBC Lifestyle HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-world-news-254" xmltv_id="BBC World News">BBC World News</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bbc-world-news-pl-322" xmltv_id="BBC World News - PL">BBC World News - PL</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/beate-uhse-tv-256" xmltv_id="Beate-Uhse.TV">Beate-Uhse.TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/belarus-24-678" xmltv_id="Belarus 24">Belarus 24</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/belgia-tv1-268" xmltv_id="Belgia - TV1">Belgia - TV1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/belsat-tv-289" xmltv_id="Belsat TV">Belsat TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bibel-tv-266" xmltv_id="Bibel TV">Bibel TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bloomberg-ang-245" xmltv_id="Bloomberg (ang.)">Bloomberg (ang.)</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/blue-hustler-280" xmltv_id="Blue Hustler">Blue Hustler</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/bollywood-hd-530" xmltv_id="Bollywood HD">Bollywood HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/boomerang-270" xmltv_id="Boomerang">Boomerang</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/boomerang-hd-616" xmltv_id="Boomerang HD">Boomerang HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/br-255" xmltv_id="BR">BR</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/brava-hd-540" xmltv_id="Brava HD">Brava HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/brazzers-tv-europe-279" xmltv_id="Brazzers TV Europe">Brazzers TV Europe</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/brava-hd-51" xmltv_id="brava hd">brava hd</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-246" xmltv_id="CANAL+">CANAL+</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-1-295" xmltv_id="CANAL+ 1">CANAL+ 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-1-hd-299" xmltv_id="CANAL+ 1 HD">CANAL+ 1 HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-discovery-307" xmltv_id="CANAL+ Discovery">CANAL+ Discovery</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-discovery-hd-308" xmltv_id="CANAL+ Discovery HD">CANAL+ Discovery HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-4k-ultra-hd-638" xmltv_id="CANAL+ 4K Ultra HD">CANAL+ 4K Ultra HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-discovery-307" xmltv_id="CANAL+ DOKUMENT">CANAL+ DOKUMENT</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-discovery-hd-308" xmltv_id="CANAL+ DOKUMENT HD">CANAL+ DOKUMENT HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-family-296" xmltv_id="CANAL+ Family">CANAL+ Family</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-family-hd-297" xmltv_id="CANAL+ Family HD">CANAL+ Family HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-film-320" xmltv_id="CANAL+ Film">CANAL+ Film</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-film-hd-278" xmltv_id="CANAL+ Film HD">CANAL+ Film HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-hd-288" xmltv_id="CANAL+ HD">CANAL+ HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kanal-38-497" xmltv_id="CANAL+ NOW">CANAL+ NOW</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-seriale-293" xmltv_id="CANAL+ Seriale">CANAL+ Seriale</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-seriale-hd-298" xmltv_id="CANAL+ Seriale HD">CANAL+ Seriale HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-14" xmltv_id="CANAL+ Sport">CANAL+ Sport</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-2-15" xmltv_id="CANAL+ Sport 2">CANAL+ Sport 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-2-hd-13" xmltv_id="CANAL+ Sport 2 HD">CANAL+ Sport 2 HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-3-674" xmltv_id="CANAL+ Sport 3">CANAL+ Sport 3</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-3-hd-676" xmltv_id="CANAL+ Sport 3 HD">CANAL+ Sport 3 HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-4-675" xmltv_id="CANAL+ Sport 4">CANAL+ Sport 4</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-4-hd-677" xmltv_id="CANAL+ Sport 4 HD">CANAL+ Sport 4 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/canal-sport-hd-12" xmltv_id="CANAL+ Sport HD">CANAL+ Sport HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cartoon-network-273" xmltv_id="Cartoon Network">Cartoon Network</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cartoon-network-tnt-313" xmltv_id="Cartoon Network/TNT">Cartoon Network/TNT</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cartoon-network-hd-310" xmltv_id="Cartoon Network HD">Cartoon Network HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cbs-action-315" xmltv_id="CBS Action">CBS Action</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cbs-drama-311" xmltv_id="CBS Drama">CBS Drama</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cbs-europa-317" xmltv_id="CBS Europa">CBS Europa</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cbs-europa-hd-309" xmltv_id="CBS Europa HD">CBS Europa HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cbs-reality-318" xmltv_id="CBS Reality">CBS Reality</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cctv-news-291" xmltv_id="CCTV News">CCTV News</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cctv-news-291" xmltv_id="CGTN">CGTN</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/channel-21-shop-267" xmltv_id="Channel 21 Shop">Channel 21 Shop</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/channel-one-russia-276" xmltv_id="Channel One Russia">Channel One Russia</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cinemax-59" xmltv_id="Cinemax">Cinemax</channel>
@@ -90,23 +104,23 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cinemax2-hd-56" xmltv_id="Cinemax2 HD">Cinemax2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cinemax-hd-57" xmltv_id="Cinemax HD">Cinemax HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ci-polsat-257" xmltv_id="CI POLSAT">CI POLSAT</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/classica-259" xmltv_id="Classica">Classica</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/classica-hd-281" xmltv_id="Classica HD">Classica HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ci-polsat-hd-640" xmltv_id="CI POLSAT HD">CI POLSAT HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cnbc-247" xmltv_id="CNBC">CNBC</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cnn-258" xmltv_id="CNN">CNN</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/cnn-pl-314" xmltv_id="CNN - PL">CNN - PL</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/comedy-central-63" xmltv_id="Comedy Central">Comedy Central</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/comedy-central-family-61" xmltv_id="Comedy Central Family">Comedy Central Family</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/comedy-central-family-hd-612" xmltv_id="Comedy Central Family HD">Comedy Central Family HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/comedy-central-hd-60" xmltv_id="Comedy Central HD">Comedy Central HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ct-1-241" xmltv_id="CT 1">CT 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ct-2-243" xmltv_id="CT 2">CT 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/czworka-polskie-radio-133" xmltv_id="Czwórka Polskie Radio">Czwórka Polskie Radio</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/czworka-polskie-radio-hd-140" xmltv_id="Czwórka Polskie Radio HD">Czwórka Polskie Radio HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/c-music-tv-260" xmltv_id="C Music TV">C Music TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dami-skarzysko-kamienna-174" xmltv_id="Dami Skarżysko-Kamienna">Dami Skarżysko-Kamienna</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/das-erste-350" xmltv_id="Das Erste">Das Erste</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/das-erste-hd-134" xmltv_id="Das Erste HD">Das Erste HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/da-vinci-learning-83" xmltv_id="Da Vinci Learning">Da Vinci Learning</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/da-vinci-learning-83" xmltv_id="Da Vinci">Da Vinci</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/da-vinci-hd-614" xmltv_id="Da Vinci HD">Da Vinci HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/deutsches-musik-fernsehen-119" xmltv_id="Deutsches Musik Fernsehen">Deutsches Musik Fernsehen</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-channel-202" xmltv_id="Discovery Channel">Discovery Channel</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-channel-hd-67" xmltv_id="Discovery Channel HD">Discovery Channel HD</channel>
@@ -114,51 +128,66 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-hd-niem-450" xmltv_id="Discovery HD (niem.)">Discovery HD (niem.)</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-historia-54" xmltv_id="Discovery Historia">Discovery Historia</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-life-187" xmltv_id="Discovery Life">Discovery Life</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-life-hd-547" xmltv_id="Discovery Life HD">Discovery Life HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-science-53" xmltv_id="Discovery Science">Discovery Science</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-science-hd-52" xmltv_id="Discovery Science HD">Discovery Science HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-turbo-xtra-239" xmltv_id="Discovery Turbo Xtra">Discovery Turbo Xtra</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-turbo-xtra-hd-189" xmltv_id="Discovery Turbo Xtra HD">Discovery Turbo Xtra HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/disco-polo-music-191" xmltv_id="Disco Polo Music">Disco Polo Music</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/disney-channel-478" xmltv_id="Disney Channel">Disney Channel</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/disney-channel-hd-216" xmltv_id="Disney Channel HD">Disney Channel HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/disney-cinemagic-455" xmltv_id="Disney Cinemagic">Disney Cinemagic</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/disney-junior-469" xmltv_id="Disney Junior">Disney Junior</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/disney-xd-235" xmltv_id="Disney XD">Disney XD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/djazz-tv-196" xmltv_id="DJAZZ.tv">DJAZZ.tv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dmax-428" xmltv_id="DMAX">DMAX</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/docubox-167" xmltv_id="DocuBox">DocuBox</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/docubox-hd-175" xmltv_id="DocuBox HD">DocuBox HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/domo-106" xmltv_id="Domo+">Domo+</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/domo-hd-437" xmltv_id="Domo+ HD">Domo+ HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dorcel-tv-507" xmltv_id="Dorcel TV">Dorcel TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dorcel-tv-hd-660" xmltv_id="Dorcel TV HD">Dorcel TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dorcel-xxx-506" xmltv_id="Dorcel XXX">Dorcel XXX</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dorcel-xxx-hd-615" xmltv_id="Dorcel XXX HD">Dorcel XXX HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dr-1-359" xmltv_id="DR 1">DR 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dr-2-361" xmltv_id="DR 2">DR 2</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-turbo-xtra-239" xmltv_id="DTX">DTX</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/discovery-turbo-xtra-hd-189" xmltv_id="DTX HD">DTX HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dw-364" xmltv_id="DW">DW</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/dlaciebie-tv-442" xmltv_id="dlaCiebie.tv">dlaCiebie.tv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ducktv-94" xmltv_id="ducktv">ducktv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ducktv-hd-151" xmltv_id="ducktv HD">ducktv HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/einsfestival-363" xmltv_id="EinsFestival">EinsFestival</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/echo-24-hd-599" xmltv_id="Echo 24 HD">Echo 24 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/einslive-427" xmltv_id="EinsLive">EinsLive</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/einsplus-484" xmltv_id="EinsPlus">EinsPlus</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-208" xmltv_id="Eleven">Eleven</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-hd-227" xmltv_id="Eleven HD">Eleven HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-hd-sports-228" xmltv_id="Eleven HD Sports">Eleven HD Sports</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-sports-212" xmltv_id="Eleven Sports">Eleven Sports</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-208" xmltv_id="Eleven Sports 1">Eleven Sports 1</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-sports-1-4k-667" xmltv_id="Eleven Sports 1 4K">Eleven Sports 1 4K</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-hd-227" xmltv_id="Eleven Sports 1 HD">Eleven Sports 1 HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-sports-212" xmltv_id="Eleven Sports 2">Eleven Sports 2</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-hd-sports-228" xmltv_id="Eleven Sports 2 HD">Eleven Sports 2 HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-extra-531" xmltv_id="Eleven Sports 3">Eleven Sports 3</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-extra-hd-534" xmltv_id="Eleven Sports 3 HD">Eleven Sports 3 HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-sports-4-607" xmltv_id="Eleven Sports 4">Eleven Sports 4</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eleven-sports-4-hd-611" xmltv_id="Eleven Sports 4 HD">Eleven Sports 4 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/english-club-tv-148" xmltv_id="English Club TV">English Club TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/english-club-tv-hd-181" xmltv_id="English Club TV HD">English Club TV HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/epic-drama-610" xmltv_id="Epic Drama">Epic Drama</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/epic-drama-hd-603" xmltv_id="Epic Drama HD">Epic Drama HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eroxxx-hd-512" xmltv_id="Eroxxx HD">Eroxxx HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/erox-hd-520" xmltv_id="Erox HD">Erox HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hip-hop-tv-511" xmltv_id="Eska Rock TV">Eska Rock TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eska-tv-114" xmltv_id="Eska TV">Eska TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eska-tv-extra-597" xmltv_id="Eska TV Extra">Eska TV Extra</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eska-tv-hd-221" xmltv_id="Eska TV HD">Eska TV HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/etv-473" xmltv_id="ETV">ETV</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/etv-hd-154" xmltv_id="ETV HD">ETV HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/e-sport-555" xmltv_id="E-SPORT">E-SPORT</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/e-sport-hd-556" xmltv_id="E-SPORT HD">E-SPORT HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurochannel-180" xmltv_id="Eurochannel">Eurochannel</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurochannel-hd-623" xmltv_id="Eurochannel HD">Eurochannel HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/euronews-367" xmltv_id="Euronews">Euronews</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/euronews-fr-665" xmltv_id="Euronews FR">Euronews FR</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/euronews-hd-617" xmltv_id="Euronews HD">Euronews HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurosport-1-93" xmltv_id="Eurosport 1">Eurosport 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurosport-1-hd-97" xmltv_id="Eurosport 1 HD">Eurosport 1 HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurosport-niem-366" xmltv_id="Eurosport 1 (niem.)">Eurosport 1 (niem.)</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurosport-2-76" xmltv_id="Eurosport 2">Eurosport 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurosport-2-hd-120" xmltv_id="Eurosport 2 HD">Eurosport 2 HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/eurosport-niem-366" xmltv_id="Eurosport (niem.)">Eurosport (niem.)</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ewtn-207" xmltv_id="EWTN">EWTN</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/extreme-sports-channel-231" xmltv_id="Extreme Sports Channel">Extreme Sports Channel</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/extreme-sports-channel-hd-217" xmltv_id="Extreme Sports Channel HD">Extreme Sports Channel HD</channel>
@@ -174,34 +203,40 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fightbox-hd-453" xmltv_id="FightBox HD">FightBox HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fightklub-78" xmltv_id="Fightklub">Fightklub</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fightklub-hd-168" xmltv_id="Fightklub HD">Fightklub HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-84" xmltv_id="FilmBox">FilmBox</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-action-451" xmltv_id="FilmBox Action">FilmBox Action</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-arthouse-183" xmltv_id="FilmBox Arthouse">FilmBox Arthouse</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-arthouse-hd-190" xmltv_id="FilmBox Arthouse HD">FilmBox Arthouse HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-extra-hd-86" xmltv_id="FilmBox Extra HD">FilmBox Extra HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-family-103" xmltv_id="FilmBox Family">FilmBox Family</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-premium-85" xmltv_id="FilmBox Premium">FilmBox Premium</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-premium-85" xmltv_id="FilmBox Premium HD">FilmBox Premium HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fokus-tv-46" xmltv_id="Fokus TV">Fokus TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fokus-tv-hd-47" xmltv_id="Fokus TV HD">Fokus TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/folx-tv-206" xmltv_id="Folx TV">Folx TV</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/food-network-hd-240" xmltv_id="Food Network HD">Food Network HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-food-157" xmltv_id="Food Network">Food Network</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-food-network-hd-209" xmltv_id="Food Network HD">Food Network HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/food-network-hd-240" xmltv_id="Food Network HD - EN">Food Network HD - EN</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fox-127" xmltv_id="FOX">FOX</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fox-comedy-75" xmltv_id="FOX Comedy">FOX Comedy</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fox-comedy-hd-405" xmltv_id="FOX Comedy HD">FOX Comedy HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/fox-hd-128" xmltv_id="FOX HD">FOX HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-24-491" xmltv_id="France 24">France 24</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-24-hd-632" xmltv_id="France 24 HD">France 24 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-24-en-70" xmltv_id="France 24 - EN">France 24 - EN</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-24-en-hd-657" xmltv_id="France 24 - EN HD">France 24 - EN HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-2-pl-329" xmltv_id="France 2 - PL">France 2 - PL</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-3-464" xmltv_id="France 3">France 3</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-5-111" xmltv_id="France 5">France 5</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/france-o-112" xmltv_id="France O">France O</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/franken-fernsehen-370" xmltv_id="Franken Fernsehen">Franken Fernsehen</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ginx-tv-503" xmltv_id="GINX TV">GINX TV</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ginx-tv-hd-504" xmltv_id="GINX TV HD">GINX TV HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/funbox-4k-605" xmltv_id="FunBox UHD">FunBox UHD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/gametoon-hd-602" xmltv_id="Gametoon HD">Gametoon HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ginx-tv-503" xmltv_id="Ginx eSports TV">Ginx eSports TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ginx-tv-hd-504" xmltv_id="Ginx eSports TV HD">Ginx eSports TV HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/god-tv-683" xmltv_id="God TV">God TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/goldstar-tv-371" xmltv_id="Goldstar TV">Goldstar TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/golf-channel-553" xmltv_id="Golf Channel">Golf Channel</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/golf-channel-hd-554" xmltv_id="Golf Channel HD">Golf Channel HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/gotv-452" xmltv_id="gotv">gotv</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/h2-203" xmltv_id="H2">H2</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/h2-hd-205" xmltv_id="H2 HD">H2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hamburg-1-373" xmltv_id="Hamburg 1">Hamburg 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hbo-23" xmltv_id="HBO">HBO</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hbo2-24" xmltv_id="HBO2">HBO2</channel>
@@ -210,8 +245,11 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hbo-3-hd-28" xmltv_id="HBO3 HD">HBO3 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hbo-hd-26" xmltv_id="HBO HD">HBO HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/heimatkanal-372" xmltv_id="Heimatkanal">Heimatkanal</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hip-hop-tv-511" xmltv_id="HIP HOP TV">HIP HOP TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-meteo-active-79" xmltv_id="HGTV">HGTV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hgtv-hd-558" xmltv_id="HGTV HD">HGTV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/history-91" xmltv_id="HISTORY">HISTORY</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/h2-203" xmltv_id="HISTORY2">HISTORY2</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/h2-hd-205" xmltv_id="HISTORY2 HD">HISTORY2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/history-hd-92" xmltv_id="HISTORY HD">HISTORY HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/history-hd-niem-458" xmltv_id="HISTORY HD (niem.)">HISTORY HD (niem.)</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hr-374" xmltv_id="HR">HR</channel>
@@ -220,32 +258,42 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/hustler-tv-107" xmltv_id="Hustler TV">Hustler TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/id-117" xmltv_id="ID">ID</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/id-hd-188" xmltv_id="ID HD">ID HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/insight-tv-uhd-682" xmltv_id="Insight TV UHD">Insight TV UHD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/inspiration-tv-649" xmltv_id="Inspiration TV">Inspiration TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ipol-tv-501" xmltv_id="iPol TV">iPol TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/itvs-661" xmltv_id="iTVS">iTVS</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/jazz-650" xmltv_id="JAZZ HD">JAZZ HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/junior-niem-375" xmltv_id="Junior (niem.)">Junior (niem.)</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kabel-eins-376" xmltv_id="Kabel Eins">Kabel Eins</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kanal-38-497" xmltv_id="Kanał 38">Kanał 38</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ki-ka-377" xmltv_id="KI.KA">KI.KA</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kino-polska-324" xmltv_id="Kino Polska">Kino Polska</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kino-polska-hd-658" xmltv_id="Kino Polska HD">Kino Polska HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kino-polska-international-493" xmltv_id="Kino Polska International">Kino Polska International</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kino-polska-muzyka-426" xmltv_id="Kino Polska Muzyka">Kino Polska Muzyka</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kino-polska-muzyka-international-195" xmltv_id="Kino Polska Muzyka International">Kino Polska Muzyka International</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/filmbox-84" xmltv_id="Kino TV">Kino TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kino-tv-hd-663" xmltv_id="Kino TV HD">Kino TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ksw-513" xmltv_id="KSW">KSW</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ksw-hd-515" xmltv_id="KSW HD">KSW HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kuchnia-489" xmltv_id="Kuchnia+">Kuchnia+</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/kuchnia-hd-434" xmltv_id="Kuchnia+ HD">Kuchnia+ HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/lifetime-50" xmltv_id="Lifetime">Lifetime</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/lifetime-hd-49" xmltv_id="Lifetime HD">Lifetime HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/liubimoe-kino-608" xmltv_id="Liubimoe Kino">Liubimoe Kino</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/love-81" xmltv_id="LOVE">LOVE</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/love-hd-629" xmltv_id="LOVE HD">LOVE HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/lubelska-tv-210" xmltv_id="Lubelska.tv">Lubelska.tv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mango-24-113" xmltv_id="Mango 24">Mango 24</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mcm-top-459" xmltv_id="MCM Top">MCM Top</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mdr-381" xmltv_id="MDR">MDR</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/metro-535" xmltv_id="METRO">METRO</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/metro-hd-536" xmltv_id="METRO HD">METRO HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mezzo-234" xmltv_id="Mezzo">Mezzo</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mezzo-live-hd-398" xmltv_id="Mezzo Live HD">Mezzo Live HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mgm-niem-456" xmltv_id="MGM (niem.)">MGM (niem.)</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/minimini-236" xmltv_id="MiniMini+">MiniMini+</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/minimini-hd-435" xmltv_id="MiniMini+ HD">MiniMini+ HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/motors-tv-479" xmltv_id="Motors TV">Motors TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/motors-tv-479" xmltv_id="Motorsport TV">Motorsport TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/motorvision-341" xmltv_id="Motorvision">Motorvision</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/motowizja-178" xmltv_id="Motowizja">Motowizja</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/motowizja-hd-194" xmltv_id="Motowizja HD">Motowizja HD</channel>
@@ -255,42 +303,54 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mtv-germany-382" xmltv_id="MTV Germany">MTV Germany</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mtv-hits-476" xmltv_id="MTV Hits">MTV Hits</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mtv-live-hd-105" xmltv_id="MTV Live HD">MTV Live HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/viva-polska-10" xmltv_id="MTV Music">MTV Music</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mtv-polska-7" xmltv_id="MTV Polska">MTV Polska</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mtv-polska-hd-557" xmltv_id="MTV Polska HD">MTV Polska HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/mtv-rocks-344" xmltv_id="MTV Rocks">MTV Rocks</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/muzo-tv-200" xmltv_id="Muzo.tv">Muzo.tv</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/music-box-538" xmltv_id="Music Box">Music Box</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/music-box-hd-539" xmltv_id="Music Box HD">Music Box HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/m-6-215" xmltv_id="M 6">M 6</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/muenchen-tv-486" xmltv_id="muenchen.tv">muenchen.tv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/muenchen-2-343" xmltv_id="muenchen 2">muenchen 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/myzen-tv-hd-396" xmltv_id="myZen.tv HD">myZen.tv HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/national-geographic-channel-32" xmltv_id="National Geographic Channel">National Geographic Channel</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/national-geographic-channel-hd-34" xmltv_id="National Geographic Channel HD">National Geographic Channel HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/national-geographic-channel-32" xmltv_id="National Geographic">National Geographic</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/national-geographic-channel-hd-34" xmltv_id="National Geographic HD">National Geographic HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nat-geo-wild-77" xmltv_id="National Geographic Wild">National Geographic Wild</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nat-geo-wild-hd-121" xmltv_id="National Geographic Wild HD">National Geographic Wild HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nat-geo-people-625" xmltv_id="Nat Geo People">Nat Geo People</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nat-geo-people-hd-211" xmltv_id="Nat Geo People HD">Nat Geo People HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nat-geo-wild-77" xmltv_id="Nat Geo Wild">Nat Geo Wild</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nat-geo-wild-hd-121" xmltv_id="Nat Geo Wild HD">Nat Geo Wild HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nautical-channel-116" xmltv_id="Nautical Channel">Nautical Channel</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nautical-channel-hd-626" xmltv_id="Nautical Channel HD">Nautical Channel HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ndr-383" xmltv_id="NDR">NDR</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nhk-world-tv-11" xmltv_id="NHK World TV">NHK World TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nick-488" xmltv_id="NICK">NICK</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nickelodeon-42" xmltv_id="Nickelodeon">Nickelodeon</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nickelodeon-hd-44" xmltv_id="Nickelodeon HD">Nickelodeon HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nickelodeon-hd-44" xmltv_id="Nicktoons">Nicktoons</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nicktoons-hd-631" xmltv_id="Nicktoons HD">Nicktoons HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nick-jr-45" xmltv_id="Nick Jr.">Nick Jr.</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nick-jr-hd-662" xmltv_id="Nick Jr. HD">Nick Jr. HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rtl-nitro-545" xmltv_id="Nitro">Nitro</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nobox-tv-634" xmltv_id="NOBOX TV">NOBOX TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nobox-tv-hd-647" xmltv_id="NOBOX TV HD">NOBOX TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nova-331" xmltv_id="Nova">Nova</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/novela-tv-461" xmltv_id="Novela tv">Novela tv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/novela-tv-hd-155" xmltv_id="Novela tv HD">Novela tv HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nowa-tv-528" xmltv_id="Nowa TV">Nowa TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nowa-tv-hd-529" xmltv_id="Nowa TV HD">Nowa TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/npo-1-385" xmltv_id="NPO 1">NPO 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/npo-2-505" xmltv_id="NPO 2">NPO 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/npo-3-387" xmltv_id="NPO 3">NPO 3</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ntl-radomsko-184" xmltv_id="NTL Radomsko">NTL Radomsko</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nuta-tv-214" xmltv_id="Nuta.TV">Nuta.TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nuta-tv-hd-213" xmltv_id="Nuta.TV HD">Nuta.TV HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/n-24-384" xmltv_id="N 24">N 24</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nsport-19" xmltv_id="nSport+">nSport+</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/nsport-hd-17" xmltv_id="nSport+ HD">nSport+ HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/n-tv-388" xmltv_id="n-tv">n-tv</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/einsfestival-363" xmltv_id="ONE">ONE</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ontv-137" xmltv_id="ONTV">ONTV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ontv-hd-161" xmltv_id="ONTV HD">ONTV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/opoka-tv-48" xmltv_id="OPOKA.TV">OPOKA.TV</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/orange-sport-102" xmltv_id="Orange Sport">Orange Sport</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/opoka-tv-hd-559" xmltv_id="OPOKA.TV HD">OPOKA.TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/orf-1-390" xmltv_id="ORF 1">ORF 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/orf-2-393" xmltv_id="ORF 2">ORF 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/outdoor-channel-hd-389" xmltv_id="Outdoor Channel HD">Outdoor Channel HD</channel>
@@ -300,25 +360,34 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/planete-hd-432" xmltv_id="Planete+ HD">Planete+ HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/playboy-tv-482" xmltv_id="Playboy TV">Playboy TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polonia-1-328" xmltv_id="Polonia 1">Polonia 1</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-fight-hd-648" xmltv_id="Polonia 1">Polonia 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polo-tv-135" xmltv_id="Polo TV">Polo TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-38" xmltv_id="POLSAT">POLSAT</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-1-36" xmltv_id="POLSAT 1">POLSAT 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-2-327" xmltv_id="POLSAT 2">POLSAT 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-2-hd-218" xmltv_id="POLSAT 2 HD">POLSAT 2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-boxing-night-510" xmltv_id="POLSAT Boxing Night">POLSAT Boxing Night</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-boxing-night-hd-522" xmltv_id="POLSAT Boxing Night HD">POLSAT Boxing Night HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-caf-110" xmltv_id="POLSAT Café">POLSAT Café</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-caf-hd-219" xmltv_id="POLSAT Café HD">POLSAT Café HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-doku-548" xmltv_id="POLSAT Doku">POLSAT Doku</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-doku-hd-551" xmltv_id="POLSAT Doku HD">POLSAT Doku HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-film-123" xmltv_id="POLSAT Film">POLSAT Film</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-film-hd-162" xmltv_id="POLSAT Film HD">POLSAT Film HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-food-157" xmltv_id="POLSAT Food">POLSAT Food</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-food-network-hd-209" xmltv_id="POLSAT Food Network HD">POLSAT Food Network HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-games-653" xmltv_id="POLSAT Games">POLSAT Games</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-games-hd-670" xmltv_id="POLSAT Games HD">POLSAT Games HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-hd-35" xmltv_id="POLSAT HD">POLSAT HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-jimjam-89" xmltv_id="POLSAT JimJam">POLSAT JimJam</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-music-564" xmltv_id="POLSAT Music">POLSAT Music</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/muzo-tv-200" xmltv_id="POLSAT Music HD">POLSAT Music HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-news-100" xmltv_id="POLSAT News">POLSAT News</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-news-2-471" xmltv_id="POLSAT News 2">POLSAT News 2</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-news-2-hd-671" xmltv_id="POLSAT News 2 HD">POLSAT News 2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-news-hd-229" xmltv_id="POLSAT News HD">POLSAT News HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-play-21" xmltv_id="POLSAT Play">POLSAT Play</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-play-hd-22" xmltv_id="POLSAT Play HD">POLSAT Play HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-rodzina-651" xmltv_id="POLSAT Rodzina">POLSAT Rodzina</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-rodzina-hd-672" xmltv_id="POLSAT Rodzina HD">POLSAT Rodzina HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-romans-173" xmltv_id="POLSAT Romans">POLSAT Romans</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-334" xmltv_id="POLSAT Sport">POLSAT Sport</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-2-516" xmltv_id="POLSAT Sport 2">POLSAT Sport 2</channel>
@@ -327,22 +396,33 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-3-hd-519" xmltv_id="POLSAT Sport 3 HD">POLSAT Sport 3 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-extra-485" xmltv_id="POLSAT Sport Extra">POLSAT Sport Extra</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-extra-hd-144" xmltv_id="POLSAT Sport Extra HD">POLSAT Sport Extra HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-fight-546" xmltv_id="POLSAT Sport Fight">POLSAT Sport Fight</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-fight-521" xmltv_id="POLSAT Sport Fight HD">POLSAT Sport Fight HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-hd-96" xmltv_id="POLSAT Sport HD">POLSAT Sport HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-news-431" xmltv_id="POLSAT Sport News">POLSAT Sport News</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-news-hd-543" xmltv_id="POLSAT Sport News HD">POLSAT Sport News HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-premium-1-643" xmltv_id="POLSAT Sport Premium 1">POLSAT Sport Premium 1</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-premium-2-644" xmltv_id="POLSAT Sport Premium 2">POLSAT Sport Premium 2</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-premium-3-645" xmltv_id="POLSAT Sport Premium 3">POLSAT Sport Premium 3</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-premium-4-646" xmltv_id="POLSAT Sport Premium 4">POLSAT Sport Premium 4</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-premium-5-642" xmltv_id="POLSAT Sport Premium 5">POLSAT Sport Premium 5</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-sport-premium-6-641" xmltv_id="POLSAT Sport Premium 6">POLSAT Sport Premium 6</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-viasat-explore-hd-82" xmltv_id="POLSAT Viasat Explore HD">POLSAT Viasat Explore HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-viasat-history-hd-71" xmltv_id="POLSAT Viasat History HD">POLSAT Viasat History HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-viasat-nature-413" xmltv_id="POLSAT Viasat Nature">POLSAT Viasat Nature</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polsat-viasat-nature-413" xmltv_id="POLSAT Viasat Nature HD">POLSAT Viasat Nature HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polskie-radio-program-1-460" xmltv_id="Polskie Radio Program 1">Polskie Radio Program 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/polskie-radio-program-2-494" xmltv_id="Polskie Radio Program 2">Polskie Radio Program 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/pomorska-tv-146" xmltv_id="Pomorska.TV">Pomorska.TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/power-tv-176" xmltv_id="Power TV">Power TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/power-tv-hd-177" xmltv_id="Power TV HD">Power TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/press-tv-66" xmltv_id="Press TV">Press TV</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/private-tv-351" xmltv_id="Private TV">Private TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/private-tv-351" xmltv_id="Private TV HD">Private TV HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/proart-hd-606" xmltv_id="PROART HD">PROART HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/pro-7-395" xmltv_id="PRO 7">PRO 7</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/puls-2-439" xmltv_id="PULS 2">PULS 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/puls-2-hd-199" xmltv_id="PULS 2 HD">PULS 2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/qvc-397" xmltv_id="QVC">QVC</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/q-polska-hd-666" xmltv_id="Q Polska HD">Q Polska HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rai-1-338" xmltv_id="RAI 1">RAI 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rai-2-336" xmltv_id="RAI 2">RAI 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rai-3-337" xmltv_id="RAI 3">RAI 3</channel>
@@ -351,14 +431,16 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/record-tv-64" xmltv_id="Record TV">Record TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/redlight-499" xmltv_id="Redlight">Redlight</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/redlight-hd-498" xmltv_id="Redlight HD">Redlight HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/etv-473" xmltv_id="Red Carpet TV">Red Carpet TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/etv-hd-154" xmltv_id="Red Carpet TV HD">Red Carpet TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rfm-tv-95" xmltv_id="RFM TV">RFM TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rnf-487" xmltv_id="RNF">RNF</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/romance-tv-129" xmltv_id="Romance TV">Romance TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/romance-tv-hd-139" xmltv_id="Romance TV HD">Romance TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rossija-24-124" xmltv_id="Rossija 24">Rossija 24</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rtl-401" xmltv_id="RTL">RTL</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rtl-2-399" xmltv_id="RTLZWEI">RTLZWEI</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rtl-102-5-43" xmltv_id="RTL 102.5">RTL 102.5</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rtl-2-399" xmltv_id="RTL 2">RTL 2</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rtl-hd-204" xmltv_id="RTL HD">RTL HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rtr-planeta-470" xmltv_id="RTR Planeta">RTR Planeta</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rts-deux-411" xmltv_id="RTS Deux">RTS Deux</channel>
@@ -369,7 +451,10 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/russia-today-hd-164" xmltv_id="Russia Today HD">Russia Today HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/rheinmaintv-468" xmltv_id="rheinmaintv">rheinmaintv</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sat-1-404" xmltv_id="SAT.1">SAT.1</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/scifi-universal-20" xmltv_id="Scifi Universal">Scifi Universal</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sbn-630" xmltv_id="SBN">SBN</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/scifi-universal-20" xmltv_id="SCI FI">SCI FI</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sci-fi-hd-628" xmltv_id="SCI FI HD">SCI FI HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/servus-tv-673" xmltv_id="Servus TV">Servus TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sky-action-368" xmltv_id="Sky Action">Sky Action</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sky-cinema-480" xmltv_id="Sky Cinema">Sky Cinema</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sky-cinema-1-465" xmltv_id="Sky Cinema + 1">Sky Cinema + 1</channel>
@@ -393,6 +478,7 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/spice-80" xmltv_id="Spice">Spice</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/spiegel-geschichte-379" xmltv_id="Spiegel Geschichte">Spiegel Geschichte</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sportklub-29" xmltv_id="Sportklub">Sportklub</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sportklub-hd-620" xmltv_id="Sportklub HD">Sportklub HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sport-1-362" xmltv_id="Sport 1">Sport 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sport-1-pl-99" xmltv_id="Sport 1 - PL">Sport 1 - PL</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/spreekanal-502" xmltv_id="Spreekanal">Spreekanal</channel>
@@ -400,19 +486,40 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/srf-zwei-407" xmltv_id="SRF Zwei">SRF Zwei</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stars-tv-149" xmltv_id="STARS.TV">STARS.TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stars-tv-hd-122" xmltv_id="STARS.TV HD">STARS.TV HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stopklatka-hd-186" xmltv_id="Stopklatka HD">Stopklatka HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stopklatka-tv-185" xmltv_id="Stopklatka TV">Stopklatka TV</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sundance-channel-237" xmltv_id="Sundance Channel">Sundance Channel</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sundance-channel-hd-392" xmltv_id="Sundance Channel HD">Sundance Channel HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stars-xxx-tv-652" xmltv_id="Stars XXX TV">Stars XXX TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/brava-hd-51" xmltv_id="Stingray Brava">Stingray Brava</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stingray-brava-hd-618" xmltv_id="Stingray Brava HD">Stingray Brava HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/classica-259" xmltv_id="Stingray Classica">Stingray Classica</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/classica-hd-281" xmltv_id="Stingray Classica HD">Stingray Classica HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/c-music-tv-260" xmltv_id="Stingray CMusic">Stingray CMusic</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/djazz-tv-196" xmltv_id="Stingray DJAZZ">Stingray DJAZZ</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stingray-djazz-hd-619" xmltv_id="Stingray DJAZZ HD">Stingray DJAZZ HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/festival-4k-544" xmltv_id="Stingray Festival 4K">Stingray Festival 4K</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stingray-iconcert-601" xmltv_id="Stingray iConcerts">Stingray iConcerts</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stingray-iconcerts-hd-681" xmltv_id="Stingray iConcerts HD">Stingray iConcerts HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stingray-juicebox-hd-655" xmltv_id="Stingray Juicebox HD">Stingray Juicebox HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stingray-loud-hd-654" xmltv_id="Stingray Loud HD">Stingray Loud HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stingray-retro-668" xmltv_id="Stingray Retro">Stingray Retro</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stopklatka-tv-185" xmltv_id="STOPKLATKA">STOPKLATKA</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/stopklatka-hd-186" xmltv_id="STOPKLATKA HD">STOPKLATKA HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sundance-channel-237" xmltv_id="Sundance TV">Sundance TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sundance-channel-hd-392" xmltv_id="Sundance TV HD">Sundance TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/superstacja-69" xmltv_id="Superstacja">Superstacja</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/superstacja-hd-550" xmltv_id="Superstacja HD">Superstacja HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/super-polsat-541" xmltv_id="Super Polsat">Super Polsat</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/super-polsat-hd-560" xmltv_id="Super Polsat HD">Super Polsat HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/super-rtl-400" xmltv_id="Super RTL">Super RTL</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/swr-408" xmltv_id="SWR">SWR</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/syfy-402" xmltv_id="Syfy">Syfy</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/sixx-447" xmltv_id="sixx">sixx</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tbn-polska-598" xmltv_id="TBN Polska">TBN Polska</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tbn-polska-hd-621" xmltv_id="TBN Polska HD">TBN Polska HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/telewizja-pomerania-41" xmltv_id="Telewizja Pomerania">Telewizja Pomerania</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tele-5-352" xmltv_id="Tele 5">Tele 5</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tele-5-hd-147" xmltv_id="Tele 5 HD">Tele 5 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tele-5-niem-448" xmltv_id="Tele 5 (niem.)">Tele 5 (niem.)</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tenis-premium-1-hd-563" xmltv_id="Tenis Premium 1 HD">Tenis Premium 1 HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tenis-premium-2-hd-562" xmltv_id="Tenis Premium 2 HD">Tenis Premium 2 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tf-1-463" xmltv_id="TF 1">TF 1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tlc-238" xmltv_id="TLC">TLC</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tlc-hd-163" xmltv_id="TLC HD">TLC HD</channel>
@@ -420,25 +527,29 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tnt-hd-220" xmltv_id="TNT HD">TNT HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/top-kids-225" xmltv_id="Top Kids">Top Kids</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/top-kids-hd-224" xmltv_id="Top Kids HD">Top Kids HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/top-kids-jr-hd-664" xmltv_id="Top Kids Jr HD">Top Kids Jr HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/to-tv-88" xmltv_id="TO!TV">TO!TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/toya-467" xmltv_id="TOYA">TOYA</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/trace-urban-483" xmltv_id="TRACE Urban">TRACE Urban</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/travelxp-4k-659" xmltv_id="Travelxp 4K">Travelxp 4K</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/travelxp-hd-656" xmltv_id="Travelxp HD">Travelxp HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/travel-channel-201" xmltv_id="Travel Channel">Travel Channel</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/travel-channel-hd-152" xmltv_id="Travel Channel HD">Travel Channel HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ttv-33" xmltv_id="TTV">TTV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ttv-624" xmltv_id="TTV">TTV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ttv-33" xmltv_id="TTV HD">TTV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-berlin-414" xmltv_id="TV.Berlin">TV.Berlin</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tve-330" xmltv_id="TVE">TVE</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvk-ostrowiec-192" xmltv_id="TVK Ostrowiec">TVK Ostrowiec</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-357" xmltv_id="TVN">TVN</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-24-biznes-i-swiat-6" xmltv_id="TVN24 BiS">TVN24 BiS</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-24-biznes-i-swiat-hd-537" xmltv_id="TVN24 BiS HD">TVN24 BiS HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-24-347" xmltv_id="TVN 24">TVN 24</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-24-biznes-i-swiat-6" xmltv_id="TVN 24 Biznes i Świat">TVN 24 Biznes i Świat</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-24-hd-158" xmltv_id="TVN 24 HD">TVN 24 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-7-326" xmltv_id="TVN 7">TVN 7</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-7-hd-142" xmltv_id="TVN 7 HD">TVN 7 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-fabula-4" xmltv_id="TVN Fabuła">TVN Fabuła</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-fabula-hd-37" xmltv_id="TVN Fabuła HD">TVN Fabuła HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-hd-98" xmltv_id="TVN HD">TVN HD</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-meteo-active-79" xmltv_id="TVN Meteo Active">TVN Meteo Active</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-style-472" xmltv_id="TVN Style">TVN Style</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-style-hd-141" xmltv_id="TVN Style HD">TVN Style HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvn-turbo-346" xmltv_id="TVN Turbo">TVN Turbo</channel>
@@ -464,11 +575,14 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-3-szczecin-440" xmltv_id="TVP 3 Szczecin">TVP 3 Szczecin</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-3-warszawa-446" xmltv_id="TVP 3 Warszawa">TVP 3 Warszawa</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-3-wroclaw-454" xmltv_id="TVP 3 Wrocław">TVP 3 Wrocław</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-4k-639" xmltv_id="TVP 4K">TVP 4K</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-abc-182" xmltv_id="TVP ABC">TVP ABC</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-hd-101" xmltv_id="TVP HD">TVP HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-historia-74" xmltv_id="TVP Historia">TVP Historia</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-info-462" xmltv_id="TVP Info">TVP Info</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-info-hd-525" xmltv_id="TVP Info HD">TVP Info HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-kultura-477" xmltv_id="TVP Kultura">TVP Kultura</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-kultura-hd-680" xmltv_id="TVP Kultura HD">TVP Kultura HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-polonia-325" xmltv_id="TVP Polonia">TVP Polonia</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-rozrywka-159" xmltv_id="TVP Rozrywka">TVP Rozrywka</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvp-seriale-130" xmltv_id="TVP Seriale">TVP Seriale</channel>
@@ -483,9 +597,14 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-4-hd-222" xmltv_id="TV 4 HD">TV 4 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-5-monde-europe-412" xmltv_id="TV 5 Monde Europe">TV 5 Monde Europe</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-6-429" xmltv_id="TV 6">TV 6</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-6-hd-561" xmltv_id="TV 6 HD">TV 6 HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-asta-495" xmltv_id="TV ASTA">TV ASTA</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-asta-hd-552" xmltv_id="TV ASTA HD">TV ASTA HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvo-600" xmltv_id="TV Okazje">TV Okazje</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-okazje-hd-633" xmltv_id="TV Okazje HD">TV Okazje HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-puls-332" xmltv_id="TV Puls">TV Puls</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-puls-hd-197" xmltv_id="TV Puls HD">TV Puls HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-regio-679" xmltv_id="TV Regio">TV Regio</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-regionalna-lubin-166" xmltv_id="TV Regionalna Lubin">TV Regionalna Lubin</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-relax-496" xmltv_id="TV Relax">TV Relax</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tv-republika-18" xmltv_id="TV Republika">TV Republika</channel>
@@ -496,13 +615,17 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/twoja-telewizja-morska-490" xmltv_id="Twoja Telewizja Morska">Twoja Telewizja Morska</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/teletoon-232" xmltv_id="teleTOON+">teleTOON+</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/teletoon-hd-438" xmltv_id="teleTOON+ HD">teleTOON+ HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/tvregionalna-pl-622" xmltv_id="tvregionalna.pl">tvregionalna.pl</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/uatv-549" xmltv_id="UATV">UATV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/ultra-tv-4k-669" xmltv_id="ULTRA TV 4K">ULTRA TV 4K</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/universal-channel-87" xmltv_id="Universal Channel">Universal Channel</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/universal-channel-hd-160" xmltv_id="Universal Channel HD">Universal Channel HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/vh1-9" xmltv_id="VH1">VH1</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/vh1-classic-european-345" xmltv_id="VH1 Classic European">VH1 Classic European</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/viasat-history-hd-viasat-nature-hd-424" xmltv_id="Viasat History HD/Viasat Nature HD">Viasat History HD/Viasat Nature HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/viva-8" xmltv_id="VIVA">VIVA</channel>
-    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/viva-polska-10" xmltv_id="VIVA Polska">VIVA Polska</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/vivid-red-hd-627" xmltv_id="Vivid RED HD">Vivid RED HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/vivid-touch-636" xmltv_id="Vivid Touch">Vivid Touch</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/vox-418" xmltv_id="VOX">VOX</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/vox-music-tv-193" xmltv_id="VOX Music TV">VOX Music TV</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/water-planet-415" xmltv_id="Water Planet">Water Planet</channel>
@@ -510,12 +633,19 @@
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wdr-420" xmltv_id="WDR">WDR</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wellbeing-network-230" xmltv_id="Wellbeing Network">Wellbeing Network</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wellbeing-network-hd-226" xmltv_id="Wellbeing Network HD">Wellbeing Network HD</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/n-24-384" xmltv_id="WELT">WELT</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wp-532" xmltv_id="WP">WP</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wp-hd-533" xmltv_id="WP HD">WP HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wtk-492" xmltv_id="WTK">WTK</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wpolsce-pl-635" xmltv_id="wPolsce.pl">wPolsce.pl</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/wpolsce-pl-hd-637" xmltv_id="wPolsce.pl HD">wPolsce.pl HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/xxl-126" xmltv_id="XXL">XXL</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/zdf-417" xmltv_id="ZDF">ZDF</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/zdf-hd-136" xmltv_id="ZDF HD">ZDF HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/zdf-info-430" xmltv_id="ZDF Info">ZDF Info</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/zest-tv-179" xmltv_id="Zest TV">Zest TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/zoom-tv-526" xmltv_id="ZOOM TV">ZOOM TV</channel>
+    <channel update="i" site="programtv.onet.pl" site_id="/program-tv/zoom-tv-hd-527" xmltv_id="ZOOM TV HD">ZOOM TV HD</channel>
     <channel update="i" site="programtv.onet.pl" site_id="/program-tv/zdf-kultur-419" xmltv_id="zdf.kultur">zdf.kultur</channel>
   </channels>
 </site>

--- a/siteini.pack/Poland/programtv.onet.pl.ini
+++ b/siteini.pack/Poland/programtv.onet.pl.ini
@@ -1,23 +1,35 @@
-**------------------------------------------------------------------------------------------------
+﻿**------------------------------------------------------------------------------------------------
 * @header_start
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: programtv.onet.pl
-* @MinSWversion: 1.1.1/54
+* @MinSWversion: V2.1
+* @Revision 2 - [19/01/2020] Mr Groch
+*   - Fixed country info seperated list in description
+*   - Refined rating system
+*   - Refined star rating
+*   - Changed max days to 12
 * @Revision 1 - [05/09/2018] Mr Groch
 *   - Added show info in desc header as option (better than using REX, because of country info), uncomment after "* show info in description header" to enable
 * @Revision 0 - [29/03/2016] Blackbear199
-*  - creation
+*   - creation
 * @Remarks:
 * @header_end
 **------------------------------------------------------------------------------------------------
-site {url=programtv.onet.pl|timezone=Europe/Warsaw|maxdays=7|cultureinfo=pl-PL|charset=UTF-8|titlematchfactor=90|episodesystem=onscreen}
-url_index{url|https://programtv.onet.pl|channel||urldate|}
+site {url=programtv.onet.pl|timezone=Europe/Warsaw|maxdays=12|cultureinfo=pl-PL|charset=UTF-8|titlematchfactor=90}
+site {ratingsystem=PL}
+*
+site {episodesystem=onscreen} *Enable for Onscreen Episode System
+*site {episodesystem=xmltv_ns} *Enable for xmltv_ns Episode System
+*
+*url_index{url|https://programtv.onet.pl|channel||urldate|}
+url_index{url|http://127.0.0.1/wg/programtv.onet.pl.php?urldate=|urldate|&channel=|channel|}
 url_index.headers {customheader=Accept-Encoding=gzip,deflate}
-urldate.format {list||?dzien=1|?dzien=2|?dzien=3|?dzien=4|?dzien=5|?dzien=6}
+urldate.format {list||?dzien=1|?dzien=2|?dzien=3|?dzien=4|?dzien=5|?dzien=6|?dzien=7|?dzien=8|?dzien=9|?dzien=10|?dzien=11|?dzien=12}
 *
 index_showsplit.scrub {multi|<div class="emissions">|<li class="hh|</li>|</ul>}
 *
-index_urlshow {url|https://programtv.onet.pl|<a href="||">|">}
+*index_urlshow {url|https://programtv.onet.pl|<a href="||">|">}
+index_urlshow {url|http://127.0.0.1/wg/programtv.onet.pl.php?channel=|<a href="||">|">}
 index_urlshow.headers {customheader=Accept-Encoding=gzip,deflate}
 *
 index_date.scrub {single(force pattern="yyyy-MM-dd")|<span class="date">|<span>|</span>|</span>}
@@ -40,7 +52,9 @@ actor.modify {substring(type=regex)|'temp_1' "(?:,?([^,]*))*"}
 *
 writer.scrub {single(separator=",")|<li class="header">Scenariusz:</li>|<li>|</li>|</ul>}
 starrating.scrub {multi|<span class="rating">Ocena</span>|<span class="stars stars|">|</span>|">}
+starrating.modify {addend('starrating' not"")|/5}
 rating.scrub {single|<span class="pegi pegi||"></span>|"></span>}
+rating.modify {addend('rating' not"")|+}
 productiondate.scrub {single|"datePublished": "||"|"}
 country.scrub {single|"countryOfOrigin": "||"|"}
 episode.modify {substring(type=regex)|'title' "\s*(\d*, odc.\s\d*\/*\d*)"}
@@ -56,19 +70,12 @@ episode.modify {addstart('episode' not "")|S}
 episode.modify {replace|S E|E}
 
 * show info in description header
-*temp_2.modify {addstart('starrating' not"")| ¤ 'starrating'}
-*temp_2.modify {addstart('rating' not"")| ¤ 'rating'}
-*temp_2.modify {addstart('productiondate' not"")| ¤ 'productiondate'}
-*loop {(each "temp_3" in 'country' max=10)|end}
-*temp_2.modify {addstart('temp_3' not"")|'temp_3'}
-*temp_4.modify {calculate('temp_3' not"" type=element format=F0)|'country' #}
-*temp_5.modify {calculate('temp_3' not"" type=element format=F0)|'country' 'temp_3' @}
-*temp_5.modify {calculate('temp_3' not"" format=F0)|1 +}
-*temp_2.modify {addstart('temp_4' not= 'temp_5')|/}
-*end_loop
-*temp_2.modify {addstart('temp_3' not"")|¤ }
+*temp_2.modify {addstart('starrating' not"")|##'starrating'}
+*temp_2.modify {addstart('rating' not"")|##'rating'}
+*temp_2.modify {addstart('productiondate' not"")|##'productiondate'}
+*temp_2.modify {addstart(separator="/" 'country' not"")|##'country'}
+*temp_2.modify {replace()|##| ¤ }
 *description.modify {addstart('temp_2' not"")|'temp_2'\n}
-
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)

--- a/siteini.pack/Poland/programtv.onet.pl.ini
+++ b/siteini.pack/Poland/programtv.onet.pl.ini
@@ -68,12 +68,12 @@ episode.modify {addstart('episode' not "")|S}
 episode.modify {replace|S E|E}
 
 * show info in description header
-temp_2.modify {addstart('starrating' not"")|##'starrating'}
-temp_2.modify {addstart('rating' not"")|##'rating'}
-temp_2.modify {addstart('productiondate' not"")|##'productiondate'}
-temp_2.modify {addstart(separator="/" 'country' not"")|##'country'}
-temp_2.modify {replace()|##| ¤ }
-description.modify {addstart('temp_2' not"")|'temp_2'\n}
+*temp_2.modify {addstart('starrating' not"")|##'starrating'}
+*temp_2.modify {addstart('rating' not"")|##'rating'}
+*temp_2.modify {addstart('productiondate' not"")|##'productiondate'}
+*temp_2.modify {addstart(separator="/" 'country' not"")|##'country'}
+*temp_2.modify {replace()|##| ¤ }
+*description.modify {addstart('temp_2' not"")|'temp_2'\n}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)

--- a/siteini.pack/Poland/programtv.onet.pl.ini
+++ b/siteini.pack/Poland/programtv.onet.pl.ini
@@ -5,6 +5,7 @@
 * @MinSWversion: V2.1
 * @Revision 2 - [19/01/2020] Mr Groch
 *   - Fixed country info seperated list in description
+*   - Fixed category dividing
 *   - Refined rating system
 *   - Refined star rating
 *   - Changed max days to 12
@@ -33,7 +34,7 @@ index_urlshow.headers {customheader=Accept-Encoding=gzip,deflate}
 index_date.scrub {single(force pattern="yyyy-MM-dd")|<span class="date">|<span>|</span>|</span>}
 index_start.scrub {single|<span class="hour">||</span>|</span>} 
 index_title.scrub {single|<a href=|>|</a>|<span } 
-index_category.scrub {single(separator=" ")|<span class="type">||</span>|</span>}
+index_category.scrub {single|<span class="type">||</span>|</span>}
 *index_description.scrub {single|<p>||</p>|</p>} *index page
 index_episode.modify {substring(type=regex)|'index_title' "\s*(\d*, odc.\s\d*\/*\d*)"}
 index_urlchannellogo {url(include=first)|http:|<span class="logoTV">|<img src="|"|alt}

--- a/siteini.pack/Poland/programtv.onet.pl.ini
+++ b/siteini.pack/Poland/programtv.onet.pl.ini
@@ -21,15 +21,13 @@ site {ratingsystem=PL}
 site {episodesystem=onscreen} *Enable for Onscreen Episode System
 *site {episodesystem=xmltv_ns} *Enable for xmltv_ns Episode System
 *
-*url_index{url|https://programtv.onet.pl|channel||urldate|}
-url_index{url|http://127.0.0.1/wg/programtv.onet.pl.php?urldate=|urldate|&channel=|channel|}
+url_index{url|https://programtv.onet.pl|channel||urldate|}
 url_index.headers {customheader=Accept-Encoding=gzip,deflate}
 urldate.format {list||?dzien=1|?dzien=2|?dzien=3|?dzien=4|?dzien=5|?dzien=6|?dzien=7|?dzien=8|?dzien=9|?dzien=10|?dzien=11|?dzien=12}
 *
 index_showsplit.scrub {multi|<div class="emissions">|<li class="hh|</li>|</ul>}
 *
-*index_urlshow {url|https://programtv.onet.pl|<a href="||">|">}
-index_urlshow {url|http://127.0.0.1/wg/programtv.onet.pl.php?channel=|<a href="||">|">}
+index_urlshow {url|https://programtv.onet.pl|<a href="||">|">}
 index_urlshow.headers {customheader=Accept-Encoding=gzip,deflate}
 *
 index_date.scrub {single(force pattern="yyyy-MM-dd")|<span class="date">|<span>|</span>|</span>}
@@ -82,7 +80,6 @@ episode.modify {replace|S E|E}
 **
 ** @auto_xml_channel_start
 *url_index{url|https://programtv.onet.pl/stacje}
-*url_index{url|http://127.0.0.1/wg/programtv.onet.pl.php}
 *index_site_channel.scrub {multi|<ul class="singleChannel letter_#">|title="|"|</div>}
 *index_site_id.scrub {multi|<ul class="singleChannel letter_#">|<a href="|"|</div>}
 *index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}

--- a/siteini.pack/Poland/programtv.onet.pl.ini
+++ b/siteini.pack/Poland/programtv.onet.pl.ini
@@ -68,12 +68,12 @@ episode.modify {addstart('episode' not "")|S}
 episode.modify {replace|S E|E}
 
 * show info in description header
-*temp_2.modify {addstart('starrating' not"")|##'starrating'}
-*temp_2.modify {addstart('rating' not"")|##'rating'}
-*temp_2.modify {addstart('productiondate' not"")|##'productiondate'}
-*temp_2.modify {addstart(separator="/" 'country' not"")|##'country'}
-*temp_2.modify {replace()|##| ¤ }
-*description.modify {addstart('temp_2' not"")|'temp_2'\n}
+temp_2.modify {addstart('starrating' not"")|##'starrating'}
+temp_2.modify {addstart('rating' not"")|##'rating'}
+temp_2.modify {addstart('productiondate' not"")|##'productiondate'}
+temp_2.modify {addstart(separator="/" 'country' not"")|##'country'}
+temp_2.modify {replace()|##| ¤ }
+description.modify {addstart('temp_2' not"")|'temp_2'\n}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)

--- a/siteini.pack/Poland/teleman.pl.channels.xml
+++ b/siteini.pack/Poland/teleman.pl.channels.xml
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V1.56.14 -- Jan van Straaten" site="teleman.pl">
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.1.11.0 -- Jan van Straaten" site="teleman.pl">
   <channels>
     <channel update="i" site="teleman.pl" site_id="13-Ulica" xmltv_id="13 Ulica">13 Ulica</channel>
     <channel update="i" site="teleman.pl" site_id="Ale-Kino" xmltv_id="ale kino+">ale kino+</channel>
-    <channel update="i" site="teleman.pl" site_id="Animal-Planet-HD" xmltv_id="Animal Planet HD">Animal Planet HD</channel>
+    <channel update="i" site="teleman.pl" site_id="AMC" xmltv_id="AMC">AMC</channel>
+    <channel update="i" site="teleman.pl" site_id="Animal-Planet-HD" xmltv_id="Animal Planet">Animal Planet</channel>
     <channel update="i" site="teleman.pl" site_id="ATM-Rozrywka" xmltv_id="ATM Rozrywka">ATM Rozrywka</channel>
     <channel update="i" site="teleman.pl" site_id="AXN" xmltv_id="AXN">AXN</channel>
     <channel update="i" site="teleman.pl" site_id="AXN-Black" xmltv_id="AXN Black">AXN Black</channel>
@@ -11,20 +12,21 @@
     <channel update="i" site="teleman.pl" site_id="AXN-White" xmltv_id="AXN White">AXN White</channel>
     <channel update="i" site="teleman.pl" site_id="BBC-Brit" xmltv_id="BBC Brit">BBC Brit</channel>
     <channel update="i" site="teleman.pl" site_id="BBC-Earth" xmltv_id="BBC Earth">BBC Earth</channel>
-    <channel update="i" site="teleman.pl" site_id="BBC-HD" xmltv_id="BBC HD">BBC HD</channel>
+    <channel update="i" site="teleman.pl" site_id="BBC-First" xmltv_id="BBC First">BBC First</channel>
     <channel update="i" site="teleman.pl" site_id="BBC-Lifestyle" xmltv_id="BBC Lifestyle">BBC Lifestyle</channel>
     <channel update="i" site="teleman.pl" site_id="Boomerang" xmltv_id="Boomerang">Boomerang</channel>
     <channel update="i" site="teleman.pl" site_id="CanalPlus" xmltv_id="CANAL+">CANAL+</channel>
     <channel update="i" site="teleman.pl" site_id="CanalPlus-1" xmltv_id="CANAL+ 1">CANAL+ 1</channel>
-    <channel update="i" site="teleman.pl" site_id="CanalPlus-Discovery" xmltv_id="CANAL+ Discovery">CANAL+ Discovery</channel>
+    <channel update="i" site="teleman.pl" site_id="CanalPlus-4K&quot; class=&quot;new" xmltv_id="CANAL+ 4K">CANAL+ 4K</channel>
+    <channel update="i" site="teleman.pl" site_id="CanalPlus-Dokument" xmltv_id="CANAL+ Dokument">CANAL+ Dokument</channel>
     <channel update="i" site="teleman.pl" site_id="CanalPlus-Family" xmltv_id="CANAL+ Family">CANAL+ Family</channel>
     <channel update="i" site="teleman.pl" site_id="CanalPlus-Film" xmltv_id="CANAL+ Film">CANAL+ Film</channel>
     <channel update="i" site="teleman.pl" site_id="CanalPlus-Seriale" xmltv_id="CANAL+ Seriale">CANAL+ Seriale</channel>
     <channel update="i" site="teleman.pl" site_id="CanalPlus-Sport" xmltv_id="CANAL+ Sport">CANAL+ Sport</channel>
     <channel update="i" site="teleman.pl" site_id="CanalPlus-Sport-2" xmltv_id="CANAL+ Sport 2">CANAL+ Sport 2</channel>
+    <channel update="i" site="teleman.pl" site_id="CanalPlus-Sport-3" xmltv_id="CANAL+ Sport 3">CANAL+ Sport 3</channel>
+    <channel update="i" site="teleman.pl" site_id="CanalPlus-Sport-4" xmltv_id="CANAL+ Sport 4">CANAL+ Sport 4</channel>
     <channel update="i" site="teleman.pl" site_id="Cartoon-Network" xmltv_id="Cartoon Network">Cartoon Network</channel>
-    <channel update="i" site="teleman.pl" site_id="CBS-Action" xmltv_id="CBS Action">CBS Action</channel>
-    <channel update="i" site="teleman.pl" site_id="CBS-Drama" xmltv_id="CBS Drama">CBS Drama</channel>
     <channel update="i" site="teleman.pl" site_id="CBS-Europa" xmltv_id="CBS Europa">CBS Europa</channel>
     <channel update="i" site="teleman.pl" site_id="CBS-Reality" xmltv_id="CBS Reality">CBS Reality</channel>
     <channel update="i" site="teleman.pl" site_id="Crime-Investigation-Network" xmltv_id="CI Polsat">CI Polsat</channel>
@@ -36,67 +38,81 @@
     <channel update="i" site="teleman.pl" site_id="Discovery-Historia" xmltv_id="Discovery Historia">Discovery Historia</channel>
     <channel update="i" site="teleman.pl" site_id="Discovery-Life" xmltv_id="Discovery Life">Discovery Life</channel>
     <channel update="i" site="teleman.pl" site_id="Discovery-Science" xmltv_id="Discovery Science">Discovery Science</channel>
-    <channel update="i" site="teleman.pl" site_id="Discovery-Turbo-Xtra" xmltv_id="Discovery Turbo Xtra">Discovery Turbo Xtra</channel>
     <channel update="i" site="teleman.pl" site_id="Disney-Channel" xmltv_id="Disney Channel">Disney Channel</channel>
     <channel update="i" site="teleman.pl" site_id="Disney-Junior" xmltv_id="Disney Junior">Disney Junior</channel>
     <channel update="i" site="teleman.pl" site_id="Disney-XD" xmltv_id="Disney XD">Disney XD</channel>
     <channel update="i" site="teleman.pl" site_id="Domo" xmltv_id="Domo+">Domo+</channel>
-    <channel update="i" site="teleman.pl" site_id="Eleven" xmltv_id="Eleven">Eleven</channel>
-    <channel update="i" site="teleman.pl" site_id="Eleven-Sports" xmltv_id="Eleven Sports">Eleven Sports</channel>
+    <channel update="i" site="teleman.pl" site_id="DTX" xmltv_id="DTX">DTX</channel>
+    <channel update="i" site="teleman.pl" site_id="Eleven-Sports-1" xmltv_id="Eleven Sports 1">Eleven Sports 1</channel>
+    <channel update="i" site="teleman.pl" site_id="Eleven-Sports-2" xmltv_id="Eleven Sports 2">Eleven Sports 2</channel>
+    <channel update="i" site="teleman.pl" site_id="Eleven-Sports-3" xmltv_id="Eleven Sports 3">Eleven Sports 3</channel>
+    <channel update="i" site="teleman.pl" site_id="Eleven-4" xmltv_id="Eleven Sports 4">Eleven Sports 4</channel>
+    <channel update="i" site="teleman.pl" site_id="Epic-Drama" xmltv_id="Epic Drama">Epic Drama</channel>
     <channel update="i" site="teleman.pl" site_id="Eurosport" xmltv_id="Eurosport 1">Eurosport 1</channel>
     <channel update="i" site="teleman.pl" site_id="Eurosport-2" xmltv_id="Eurosport 2">Eurosport 2</channel>
     <channel update="i" site="teleman.pl" site_id="Extreme" xmltv_id="Extreme">Extreme</channel>
-    <channel update="i" site="teleman.pl" site_id="Filmbox" xmltv_id="FilmBox">FilmBox</channel>
     <channel update="i" site="teleman.pl" site_id="Filmbox-Action" xmltv_id="Filmbox Action">Filmbox Action</channel>
+    <channel update="i" site="teleman.pl" site_id="FilmBox-Arthouse" xmltv_id="FilmBox Arthouse">FilmBox Arthouse</channel>
     <channel update="i" site="teleman.pl" site_id="Filmbox-Extra-HD" xmltv_id="FilmBox Extra HD">FilmBox Extra HD</channel>
     <channel update="i" site="teleman.pl" site_id="Filmbox-Family" xmltv_id="FilmBox Family">FilmBox Family</channel>
-    <channel update="i" site="teleman.pl" site_id="Filmbox-Premium" xmltv_id="FilmBox Premium">FilmBox Premium</channel>
+    <channel update="i" site="teleman.pl" site_id="Filmbox-Premium" xmltv_id="FilmBox Premium HD">FilmBox Premium HD</channel>
     <channel update="i" site="teleman.pl" site_id="Fokus-TV" xmltv_id="Fokus TV">Fokus TV</channel>
+    <channel update="i" site="teleman.pl" site_id="Food-Network" xmltv_id="Food Network">Food Network</channel>
     <channel update="i" site="teleman.pl" site_id="FOX" xmltv_id="FOX">FOX</channel>
     <channel update="i" site="teleman.pl" site_id="FOX-Comedy" xmltv_id="FOX Comedy">FOX Comedy</channel>
     <channel update="i" site="teleman.pl" site_id="HBO" xmltv_id="HBO">HBO</channel>
     <channel update="i" site="teleman.pl" site_id="HBO2" xmltv_id="HBO 2">HBO 2</channel>
-    <channel update="i" site="teleman.pl" site_id="HBO-Comedy" xmltv_id="HBO Comedy">HBO Comedy</channel>
+    <channel update="i" site="teleman.pl" site_id="HBO3" xmltv_id="HBO 3">HBO 3</channel>
+    <channel update="i" site="teleman.pl" site_id="HGTV" xmltv_id="HGTV">HGTV</channel>
     <channel update="i" site="teleman.pl" site_id="History" xmltv_id="HISTORY">HISTORY</channel>
+    <channel update="i" site="teleman.pl" site_id="H2" xmltv_id="HISTORY 2">HISTORY 2</channel>
     <channel update="i" site="teleman.pl" site_id="ID" xmltv_id="ID">ID</channel>
     <channel update="i" site="teleman.pl" site_id="Kino-Polska" xmltv_id="Kino Polska">Kino Polska</channel>
+    <channel update="i" site="teleman.pl" site_id="Kino%20TV" xmltv_id="Kino TV">Kino TV</channel>
     <channel update="i" site="teleman.pl" site_id="Kuchnia-TV" xmltv_id="Kuchnia+">Kuchnia+</channel>
+    <channel update="i" site="teleman.pl" site_id="Metro-TV" xmltv_id="Metro TV">Metro TV</channel>
     <channel update="i" site="teleman.pl" site_id="Mezzo" xmltv_id="Mezzo">Mezzo</channel>
-    <channel update="i" site="teleman.pl" site_id="MGM-HD" xmltv_id="MGM HD">MGM HD</channel>
     <channel update="i" site="teleman.pl" site_id="MiniMini" xmltv_id="MiniMini+">MiniMini+</channel>
     <channel update="i" site="teleman.pl" site_id="MTV-Polska" xmltv_id="MTV Polska">MTV Polska</channel>
     <channel update="i" site="teleman.pl" site_id="Nat-Geo-People" xmltv_id="Nat Geo People">Nat Geo People</channel>
-    <channel update="i" site="teleman.pl" site_id="Nat-Geo-Wild" xmltv_id="Nat Geo Wild">Nat Geo Wild</channel>
     <channel update="i" site="teleman.pl" site_id="National-Geographic" xmltv_id="National Geo.">National Geo.</channel>
+    <channel update="i" site="teleman.pl" site_id="Nat-Geo-Wild" xmltv_id="Nat. Geo. Wild">Nat. Geo. Wild</channel>
     <channel update="i" site="teleman.pl" site_id="Nickelodeon" xmltv_id="Nickelodeon">Nickelodeon</channel>
-    <channel update="i" site="teleman.pl" site_id="Nickelodeon-HD" xmltv_id="Nickelodeon HD">Nickelodeon HD</channel>
+    <channel update="i" site="teleman.pl" site_id="Nicktoons" xmltv_id="Nicktoons">Nicktoons</channel>
+    <channel update="i" site="teleman.pl" site_id="Nowa-TV" xmltv_id="Nowa TV">Nowa TV</channel>
     <channel update="i" site="teleman.pl" site_id="nSport" xmltv_id="nSport+">nSport+</channel>
-    <channel update="i" site="teleman.pl" site_id="Orange-Sport" xmltv_id="Orange Sport">Orange Sport</channel>
     <channel update="i" site="teleman.pl" site_id="Paramount-Channel" xmltv_id="Paramount Channel">Paramount Channel</channel>
     <channel update="i" site="teleman.pl" site_id="Planete" xmltv_id="PLANETE+">PLANETE+</channel>
     <channel update="i" site="teleman.pl" site_id="Polonia-1" xmltv_id="Polonia 1">Polonia 1</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat" xmltv_id="Polsat">Polsat</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-2" xmltv_id="Polsat 2">Polsat 2</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-Cafe" xmltv_id="Polsat Cafe">Polsat Cafe</channel>
+    <channel update="i" site="teleman.pl" site_id="Polsat-Doku" xmltv_id="Polsat Doku">Polsat Doku</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-Film" xmltv_id="Polsat Film">Polsat Film</channel>
+    <channel update="i" site="teleman.pl" site_id="Polsat-Games" xmltv_id="Polsat Games">Polsat Games</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-News" xmltv_id="Polsat News">Polsat News</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-Play" xmltv_id="Polsat Play">Polsat Play</channel>
+    <channel update="i" site="teleman.pl" site_id="Polsat-Rodzina" xmltv_id="Polsat Rodzina">Polsat Rodzina</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-Romans" xmltv_id="Polsat Romans">Polsat Romans</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-Sport" xmltv_id="Polsat Sport">Polsat Sport</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-Sport-Extra" xmltv_id="Polsat Sport Extra">Polsat Sport Extra</channel>
+    <channel update="i" site="teleman.pl" site_id="Polsat-Sport-Fight" xmltv_id="Polsat Sport Fight">Polsat Sport Fight</channel>
     <channel update="i" site="teleman.pl" site_id="Polsat-Sport-News" xmltv_id="Polsat Sport News">Polsat Sport News</channel>
+    <channel update="i" site="teleman.pl" site_id="Polsat-Sport-Premium-1" xmltv_id="Polsat Sport Premium 1">Polsat Sport Premium 1</channel>
+    <channel update="i" site="teleman.pl" site_id="Polsat-Sport-Premium-2" xmltv_id="Polsat Sport Premium 2">Polsat Sport Premium 2</channel>
     <channel update="i" site="teleman.pl" site_id="Viasat-Explorer" xmltv_id="Polsat Viasat Expl.">Polsat Viasat Expl.</channel>
     <channel update="i" site="teleman.pl" site_id="Viasat-History" xmltv_id="Polsat Viasat Hist.">Polsat Viasat Hist.</channel>
     <channel update="i" site="teleman.pl" site_id="Viasat-Nature" xmltv_id="Polsat Viasat Nature">Polsat Viasat Nature</channel>
-    <channel update="i" site="teleman.pl" site_id="SciFi-Channel" xmltv_id="Sci-Fi Universal">Sci-Fi Universal</channel>
+    <channel update="i" site="teleman.pl" site_id="Romance-TV" xmltv_id="Romance TV">Romance TV</channel>
+    <channel update="i" site="teleman.pl" site_id="SCI-FI" xmltv_id="SCI FI">SCI FI</channel>
     <channel update="i" site="teleman.pl" site_id="SportKlub" xmltv_id="SportKlub">SportKlub</channel>
-    <channel update="i" site="teleman.pl" site_id="Stopklatka-TV" xmltv_id="Stopklatka TV">Stopklatka TV</channel>
-    <channel update="i" site="teleman.pl" site_id="Sundance-Channel-HD" xmltv_id="Sundance Channel">Sundance Channel</channel>
+    <channel update="i" site="teleman.pl" site_id="Stopklatka-TV" xmltv_id="Stopklatka">Stopklatka</channel>
+    <channel update="i" site="teleman.pl" site_id="Sundance-Channel-HD" xmltv_id="Sundance TV">Sundance TV</channel>
+    <channel update="i" site="teleman.pl" site_id="Super-Polsat" xmltv_id="Super Polsat">Super Polsat</channel>
     <channel update="i" site="teleman.pl" site_id="Superstacja" xmltv_id="Superstacja">Superstacja</channel>
     <channel update="i" site="teleman.pl" site_id="Tele-5" xmltv_id="Tele 5">Tele 5</channel>
-    <channel update="i" site="teleman.pl" site_id="teleTOON-plus" xmltv_id="teleTOON+">teleTOON+</channel>
     <channel update="i" site="teleman.pl" site_id="TLC" xmltv_id="TLC">TLC</channel>
-    <channel update="i" site="teleman.pl" site_id="TNT" xmltv_id="TNT (dawniej TCM)">TNT (dawniej TCM)</channel>
+    <channel update="i" site="teleman.pl" site_id="TNT" xmltv_id="TNT">TNT</channel>
     <channel update="i" site="teleman.pl" site_id="Travel-Channel" xmltv_id="Travel">Travel</channel>
     <channel update="i" site="teleman.pl" site_id="TTV" xmltv_id="TTV">TTV</channel>
     <channel update="i" site="teleman.pl" site_id="TV4" xmltv_id="TV 4">TV 4</channel>
@@ -111,7 +127,7 @@
     <channel update="i" site="teleman.pl" site_id="TVN-Style" xmltv_id="TVN Style">TVN Style</channel>
     <channel update="i" site="teleman.pl" site_id="TVN-Turbo" xmltv_id="TVN Turbo">TVN Turbo</channel>
     <channel update="i" site="teleman.pl" site_id="TVN24" xmltv_id="TVN24">TVN24</channel>
-    <channel update="i" site="teleman.pl" site_id="TVN-24-Biznes-i-Swiat" xmltv_id="TVN24 BiŚ">TVN24 BiŚ</channel>
+    <channel update="i" site="teleman.pl" site_id="TVN-24-Biznes-i-Swiat" xmltv_id="TVN24 BiS">TVN24 BiS</channel>
     <channel update="i" site="teleman.pl" site_id="TVP-1" xmltv_id="TVP 1">TVP 1</channel>
     <channel update="i" site="teleman.pl" site_id="TVP-2" xmltv_id="TVP 2">TVP 2</channel>
     <channel update="i" site="teleman.pl" site_id="TVP-ABC" xmltv_id="TVP ABC">TVP ABC</channel>
@@ -124,7 +140,7 @@
     <channel update="i" site="teleman.pl" site_id="TVP-Seriale" xmltv_id="TVP Seriale">TVP Seriale</channel>
     <channel update="i" site="teleman.pl" site_id="TVP-Sport" xmltv_id="TVP Sport">TVP Sport</channel>
     <channel update="i" site="teleman.pl" site_id="TVS" xmltv_id="TVS">TVS</channel>
-    <channel update="i" site="teleman.pl" site_id="Universal-Channel" xmltv_id="Universal Channel">Universal Channel</channel>
-    <channel update="i" site="teleman.pl" site_id="VIVA-Polska" xmltv_id="VIVA Polska">VIVA Polska</channel>
+    <channel update="i" site="teleman.pl" site_id="WP" xmltv_id="WP">WP</channel>
+    <channel update="i" site="teleman.pl" site_id="Zoom-TV" xmltv_id="Zoom TV">Zoom TV</channel>
   </channels>
 </site>

--- a/siteini.pack/Poland/teleman.pl.ini
+++ b/siteini.pack/Poland/teleman.pl.ini
@@ -8,6 +8,7 @@
 *   - Refined rating
 *   - Refined star rating
 *   - Changed max days to 13
+*   - Changed to https and removed www (less redirection, faster grabbing)
 * @Revision 17 - [30/08/2018] Mr Groch
 *   - Fixed country tag when no production date in source
 *   - Fixed showicon url
@@ -60,8 +61,8 @@ site {ratingsystem=PL}
 site {episodesystem=onscreen} *Enable for Onscreen Episode System
 *site {episodesystem=xmltv_ns} *Enable for xmltv_ns Episode System
 *
-*http://www.teleman.pl/program-tv/stacje/TVP-1?date=2016-02-17
-url_index {url|http://www.teleman.pl/program-tv/stacje/|channel|?date=|urldate|}
+*https://teleman.pl/program-tv/stacje/TVP-1?date=2016-02-17
+url_index {url|https://teleman.pl/program-tv/stacje/|channel|?date=|urldate|}
 urldate.format {datestring|yyyy-MM-dd}
 *
 index_showsplit.scrub {multi|class="stationItems"|id="prog|</li>|</ul>}
@@ -84,9 +85,9 @@ index_category.modify {addstart('index_subtitle' ~ "mecz:")|Sport}
 *index_title.modify {remove(type=regex)|\d+\s\(\d+\)}
 *index_title.modify {remove(type=regex)|\s\(\d+\)}
 *
-index_urlshow {url|http://www.teleman.pl|<a href="||"|"}
+index_urlshow {url|https://teleman.pl|<a href="||"|"}
 index_urlchannellogo {url ||<div class="stationTitle">|<img src="|?v=|" alt="}
-index_urlchannellogo.modify {addstart('index_urlchannellogo' not"")|http:}
+index_urlchannellogo.modify {addstart('index_urlchannellogo' not"")|https:}
 *
 *title.scrub {regex||<h1 class="title.*?">(.*?)</h1>||}
 *title.modify {cleanup(tags="<"">")}
@@ -105,7 +106,7 @@ description.scrub {single|<h2>Opis</h2>||</div>|</div>}
 temp_3.scrub {single|<h2>W tym odcinku</h2>||</div>|</div>}
 description.modify {addend('temp_3' not"")|\n¤ W tym odcinku: 'temp_3'}
 showicon.scrub {regex||<div id="showPhoto">.*?<img src="(.*?)"||}
-showicon.modify {addstart('showicon' not"")|http:}
+showicon.modify {addstart('showicon' not"")|https:}
 country.scrub {multi(separator="/" includeblock=1)|<span class="sep">|<span>|</span>|</div>}
 *
 description.modify {cleanup(tags="<"">")}
@@ -122,12 +123,12 @@ starrating.scrub {regex||<a class="movieRank filmwebRank".*?>(.*?)</a>||}
 starrating.modify {cleanup(tags="<"">")}
 *
 * show info in description header
-*temp_4.modify {addstart('starrating' not"")|##'starrating'}
-*temp_4.modify {addstart('rating' not"")|##'rating'}
-*temp_4.modify {addstart('productiondate' not"")|##'productiondate'}
-*temp_4.modify {addstart(separator="/" 'country' not"")|##'country'}
-*temp_4.modify {replace()|##| ¤ }
-*description.modify {addstart('temp_4' not"")|'temp_4'\n}
+temp_4.modify {addstart('starrating' not"")|##'starrating'}
+temp_4.modify {addstart('rating' not"")|##'rating'}
+temp_4.modify {addstart('productiondate' not"")|##'productiondate'}
+temp_4.modify {addstart(separator="/" 'country' not"")|##'country'}
+temp_4.modify {replace()|##| ¤ }
+description.modify {addstart('temp_4' not"")|'temp_4'\n}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)

--- a/siteini.pack/Poland/teleman.pl.ini
+++ b/siteini.pack/Poland/teleman.pl.ini
@@ -123,12 +123,12 @@ starrating.scrub {regex||<a class="movieRank filmwebRank".*?>(.*?)</a>||}
 starrating.modify {cleanup(tags="<"">")}
 *
 * show info in description header
-temp_4.modify {addstart('starrating' not"")|##'starrating'}
-temp_4.modify {addstart('rating' not"")|##'rating'}
-temp_4.modify {addstart('productiondate' not"")|##'productiondate'}
-temp_4.modify {addstart(separator="/" 'country' not"")|##'country'}
-temp_4.modify {replace()|##| ¤ }
-description.modify {addstart('temp_4' not"")|'temp_4'\n}
+*temp_4.modify {addstart('starrating' not"")|##'starrating'}
+*temp_4.modify {addstart('rating' not"")|##'rating'}
+*temp_4.modify {addstart('productiondate' not"")|##'productiondate'}
+*temp_4.modify {addstart(separator="/" 'country' not"")|##'country'}
+*temp_4.modify {replace()|##| ¤ }
+*description.modify {addstart('temp_4' not"")|'temp_4'\n}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)

--- a/siteini.pack/Poland/teleman.pl.ini
+++ b/siteini.pack/Poland/teleman.pl.ini
@@ -2,8 +2,14 @@
 * @header_start
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: teleman.pl
+* @MinSWversion: V2.1
+* @Revision 18 - [19/01/2020] Mr Groch
+*   - Fixed country info seperated list in description
+*   - Refined rating
+*   - Refined star rating
+*   - Changed max days to 13
 * @Revision 17 - [30/08/2018] Mr Groch
-*	- Fixed country tag when no production date in source
+*   - Fixed country tag when no production date in source
 *   - Fixed showicon url
 *   - Refined description for series
 *   - Refined title - no grabing, use index_title for incremental update matching
@@ -17,38 +23,38 @@
 *     *index_title.modify {remove(type=regex)|\s\(\d+\)}
 *   - Added show info in desc header as option (better than using REX, because of country info), uncomment after "* show info in description header" to enable
 * @Revision 16 - [21/09/2017] Netuddki
-*	- Fixes different titles
-*       - Fixed some episode related bugs
+*   - Fixes different titles
+*   - Fixed some episode related bugs
 * @Revision 15 - [04/05/2017] Netuddki
-*	- Added country
-*	- Added Subtitle
-*	- Refined Episode and Title
+*   - Added country
+*   - Added Subtitle
+*   - Refined Episode and Title
 * @Revision 14 - [02/05/2017] Netuddki
-*	- Refined Title (no more suspicious titles)
-*	- Refined Category
-*       - Added option for Episode system xmltv_ns
-*	- Fixed showicon
+*   - Refined Title (no more suspicious titles)
+*   - Refined Category
+*   - Added option for Episode system xmltv_ns
+*   - Fixed showicon
 * @Revision 13 - [06/01/2017] Netuddki
-*	- fixed title.scrub
-*       - fixed episodes
+*   - fixed title.scrub
+*   - fixed episodes
 * @Revision 12 - [16/02/2016] Blackbear199
-*	- new .channels.xml generation
+*   - new .channels.xml generation
 *   - url_index change,index_showsplit fix
 * @Revision 11 - [20/03/2015] Willy De Wilde
-*	- new .channels.xml generation
+*   - new .channels.xml generation
 * @Revision 10 - [13/02/2013] Francis De Paemeleere
-*	- site changes
+*   - site changes
 * @Revision 9 - [20/01/2013] Willy De Wilde
-*	- site changes
+*   - site changes
 * @Revision 8 - [20/12/2012] Willy De Wilde
-*	- site changes
+*   - site changes
 * @Revision 7 - [24/11/2012] Willy De Wilde, Piotr Oleszczyk, Jan van Straaten
-*	- site changes
+*   - site changes
 * @Remarks:
 * @header_end
 **------------------------------------------------------------------------------------------------
 *
-site {url=teleman.pl|timezone=Europe/Warsaw|maxdays=12|cultureinfo=pl-PL|charset=UTF-8|titlematchfactor=50}
+site {url=teleman.pl|timezone=Europe/Warsaw|maxdays=13|cultureinfo=pl-PL|charset=UTF-8|titlematchfactor=90}
 site {ratingsystem=PL}
 *
 site {episodesystem=onscreen} *Enable for Onscreen Episode System
@@ -106,31 +112,23 @@ description.modify {cleanup(tags="<"">")}
 titleoriginal.modify {remove|Oglądaj w telewizji}
 actor.modify {remove|'director'}
 *
-rating.scrub {single|<span class="age|">|</span>|</h1>}
-rating.modify {replace(~ "b.o.")|'rating'|0+}
-rating.modify {replace(~ "od 16 lat")|'rating'|16+}
-rating.modify {replace(~ "dla dorosłych")|'rating'|18+}
-rating.modify {replace(~ "od 7 lat")|'rating'|7+}
-rating.modify {replace(~ "od 12 lat")|'rating'|12+}
+rating.scrub {regex||<span class="age-rating age-rating-(.*?)".*?>.*?</span>||}
+rating.modify {replace(~ "bo")|'rating'|0}
+rating.modify {substring(type=regex)|'rating' "\d+\"}
+rating.modify {addend('rating' not"")|+}
 *
-starrating.scrub {single|<a class="movieRank filmwebRank|<strong>|</strong>|</a}
-*starrating.scrub {single|<a class="movieRank imdbRank|<strong>|</strong>|</a}
-starrating.modify {addend('starrating' not"")|/10}
+starrating.scrub {regex||<a class="movieRank filmwebRank".*?>(.*?)</a>||}
+*starrating.scrub {regex||<a class="movieRank imdbRank".*?>(.*?)</a>||}
+starrating.modify {cleanup(tags="<"">")}
 *
 * show info in description header
-*temp_4.modify {addstart('starrating' not"")| ¤ 'starrating'}
-*temp_4.modify {addstart('rating' not"")| ¤ 'rating'}
-*temp_4.modify {addstart('productiondate' not"")| ¤ 'productiondate'}
-*loop {(each "temp_5" in 'country' max=10)|end}
-*temp_4.modify {addstart('temp_5' not"")|'temp_5'}
-*temp_6.modify {calculate('temp_5' not"" type=element format=F0)|'country' #}
-*temp_7.modify {calculate('temp_5' not"" type=element format=F0)|'country' 'temp_5' @}
-*temp_7.modify {calculate('temp_5' not"" format=F0)|1 +}
-*temp_4.modify {addstart('temp_6' not= 'temp_7')|/}
-*end_loop
-*temp_4.modify {addstart('temp_5' not"")|¤ }
+*temp_4.modify {addstart('starrating' not"")|##'starrating'}
+*temp_4.modify {addstart('rating' not"")|##'rating'}
+*temp_4.modify {addstart('productiondate' not"")|##'productiondate'}
+*temp_4.modify {addstart(separator="/" 'country' not"")|##'country'}
+*temp_4.modify {replace()|##| ¤ }
 *description.modify {addstart('temp_4' not"")|'temp_4'\n}
-
+*
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
 **


### PR DESCRIPTION
Some fixes and improvements for programtv.interia.pl, programtv.onet.pl and teleman.pl (changelog bellow) + new channels xml lists for those sites

programtv.interia.pl:

* @revision 8 - [19/01/2020] Mr Groch
*   - Fixed country info seperated list in description
*   - Fixed channel file creation mode
*   - Refined rating
*   - Changed max days to 13
*   - Changed to https

programtv.onet.pl:

* @revision 2 - [19/01/2020] Mr Groch
*   - Fixed country info seperated list in description
*   - Fixed category dividing
*   - Refined rating system
*   - Refined star rating
*   - Changed max days to 12

teleman.pl:

* @revision 18 - [19/01/2020] Mr Groch
*   - Fixed country info seperated list in description
*   - Refined rating
*   - Refined star rating
*   - Changed max days to 13
*   - Changed to https and removed www (less redirection, faster grabbing)