### PR TITLE
Updated Norwegian vg.no.ini guide

### DIFF
--- a/siteini.pack/Norway/vg.no.channels.xml
+++ b/siteini.pack/Norway/vg.no.channels.xml
@@ -1,132 +1,147 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.1.4 -- Jan van Straaten" site="vg.no">
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V2.1.5 -- Jan van Straaten" site="tvguide.vg.no">
   <channels>
-    <channel update="i" site="vg.no" site_id="8" xmltv_id="NRK1">NRK1</channel>
-    <channel update="i" site="vg.no" site_id="37" xmltv_id="VGTV">VGTV</channel>
-    <channel update="i" site="vg.no" site_id="9" xmltv_id="NRK2">NRK2</channel>
-    <channel update="i" site="vg.no" site_id="19" xmltv_id="NRK3">NRK3</channel>
-    <channel update="i" site="vg.no" site_id="10" xmltv_id="TV2">TV2</channel>
-    <channel update="i" site="vg.no" site_id="31" xmltv_id="TVNorge">TVNorge</channel>
-    <channel update="i" site="vg.no" site_id="24" xmltv_id="TV3">TV3</channel>
-    <channel update="i" site="vg.no" site_id="67" xmltv_id="Eurosport Norge">Eurosport Norge</channel>
-    <channel update="i" site="vg.no" site_id="25" xmltv_id="Viasat 4">Viasat 4</channel>
-    <channel update="i" site="vg.no" site_id="20" xmltv_id="TV2 Zebra">TV2 Zebra</channel>
-    <channel update="i" site="vg.no" site_id="12" xmltv_id="TV2 Nyhetskanalen">TV2 Nyhetskanalen</channel>
-    <channel update="i" site="vg.no" site_id="115" xmltv_id="TV2 Sport 1">TV2 Sport 1</channel>
-    <channel update="i" site="vg.no" site_id="116" xmltv_id="TV2 Sport 2">TV2 Sport 2</channel>
-    <channel update="i" site="vg.no" site_id="35" xmltv_id="TV2 Livsstil">TV2 Livsstil</channel>
-    <channel update="i" site="vg.no" site_id="34" xmltv_id="TV2 Humor">TV2 Humor</channel>
-    <channel update="i" site="vg.no" site_id="22" xmltv_id="MAX">MAX</channel>
-    <channel update="i" site="vg.no" site_id="21" xmltv_id="FEM">FEM</channel>
-    <channel update="i" site="vg.no" site_id="23" xmltv_id="VOX">VOX</channel>
-    <channel update="i" site="vg.no" site_id="54" xmltv_id="TV6 Norge">TV6 Norge</channel>
-    <channel update="i" site="vg.no" site_id="30" xmltv_id="SVT1">SVT1</channel>
-    <channel update="i" site="vg.no" site_id="16" xmltv_id="SVT2">SVT2</channel>
-    <channel update="i" site="vg.no" site_id="11" xmltv_id="TV4">TV4</channel>
-    <channel update="i" site="vg.no" site_id="90" xmltv_id="MTV">MTV</channel>
-    <channel update="i" site="vg.no" site_id="87" xmltv_id="Eurosport 1">Eurosport 1</channel>
-    <channel update="i" site="vg.no" site_id="1" xmltv_id="CNN">CNN</channel>
-    <channel update="i" site="vg.no" site_id="33" xmltv_id="BBC Brit">BBC Brit</channel>
-    <channel update="i" site="vg.no" site_id="14" xmltv_id="BBC Earth">BBC Earth</channel>
-    <channel update="i" site="vg.no" site_id="29" xmltv_id="National Geographic">National Geographic</channel>
-    <channel update="i" site="vg.no" site_id="56" xmltv_id="Discovery Channel">Discovery Channel</channel>
-    <channel update="i" site="vg.no" site_id="84" xmltv_id="TLC">TLC</channel>
-    <channel update="i" site="vg.no" site_id="55" xmltv_id="Animal Planet">Animal Planet</channel>
-    <channel update="i" site="vg.no" site_id="26" xmltv_id="FOX HD">FOX HD</channel>
-    <channel update="i" site="vg.no" site_id="2" xmltv_id="Travel Channel">Travel Channel</channel>
-    <channel update="i" site="vg.no" site_id="60" xmltv_id="History Channel">History Channel</channel>
-    <channel update="i" site="vg.no" site_id="62" xmltv_id="NRK Super">NRK Super</channel>
-    <channel update="i" site="vg.no" site_id="85" xmltv_id="Disney Channel">Disney Channel</channel>
-    <channel update="i" site="vg.no" site_id="89" xmltv_id="Nickelodeon">Nickelodeon</channel>
-    <channel update="i" site="vg.no" site_id="88" xmltv_id="Cartoon Network">Cartoon Network</channel>
-    <channel update="i" site="vg.no" site_id="123" xmltv_id="TNT">TNT</channel>
-    <channel update="i" site="vg.no" site_id="113" xmltv_id="TV2 Sport Premium 1">TV2 Sport Premium 1</channel>
-    <channel update="i" site="vg.no" site_id="114" xmltv_id="TV2 Sport Premium 2">TV2 Sport Premium 2</channel>
-    <channel update="i" site="vg.no" site_id="13" xmltv_id="3sat">3sat</channel>
-    <channel update="i" site="vg.no" site_id="7" xmltv_id="Al Jazeera English">Al Jazeera English</channel>
-    <channel update="i" site="vg.no" site_id="57" xmltv_id="Animal Planet HD">Animal Planet HD</channel>
-    <channel update="i" site="vg.no" site_id="39" xmltv_id="BBC World News">BBC World News</channel>
-    <channel update="i" site="vg.no" site_id="92" xmltv_id="Boomerang">Boomerang</channel>
-    <channel update="i" site="vg.no" site_id="93" xmltv_id="C More Stars">C More Stars</channel>
-    <channel update="i" site="vg.no" site_id="94" xmltv_id="C More First">C More First</channel>
-    <channel update="i" site="vg.no" site_id="91" xmltv_id="C More Hits">C More Hits</channel>
-    <channel update="i" site="vg.no" site_id="98" xmltv_id="C More Series">C More Series</channel>
-    <channel update="i" site="vg.no" site_id="112" xmltv_id="SF-kanalen">SF-kanalen</channel>
-    <channel update="i" site="vg.no" site_id="97" xmltv_id="C More Live 1">C More Live 1</channel>
-    <channel update="i" site="vg.no" site_id="96" xmltv_id="C More Hockey">C More Hockey</channel>
-    <channel update="i" site="vg.no" site_id="95" xmltv_id="C More First HD">C More First HD</channel>
-    <channel update="i" site="vg.no" site_id="44" xmltv_id="Fine Living Network">Fine Living Network</channel>
-    <channel update="i" site="vg.no" site_id="27" xmltv_id="National Geographic HD">National Geographic HD</channel>
-    <channel update="i" site="vg.no" site_id="6" xmltv_id="Sat.1">Sat.1</channel>
-    <channel update="i" site="vg.no" site_id="3" xmltv_id="Sky News">Sky News</channel>
-    <channel update="i" site="vg.no" site_id="32" xmltv_id="CNBC">CNBC</channel>
-    <channel update="i" site="vg.no" site_id="38" xmltv_id="Discovery Channel HD">Discovery Channel HD</channel>
-    <channel update="i" site="vg.no" site_id="99" xmltv_id="Disney Junior">Disney Junior</channel>
-    <channel update="i" site="vg.no" site_id="86" xmltv_id="Disney XD">Disney XD</channel>
-    <channel update="i" site="vg.no" site_id="47" xmltv_id="DR1">DR1</channel>
-    <channel update="i" site="vg.no" site_id="50" xmltv_id="DR2">DR2</channel>
-    <channel update="i" site="vg.no" site_id="58" xmltv_id="Discovery Science">Discovery Science</channel>
-    <channel update="i" site="vg.no" site_id="45" xmltv_id="SPORT1">SPORT1</channel>
-    <channel update="i" site="vg.no" site_id="51" xmltv_id="TV2 (Danmark)">TV2 (Danmark)</channel>
-    <channel update="i" site="vg.no" site_id="49" xmltv_id="DW">DW</channel>
-    <channel update="i" site="vg.no" site_id="59" xmltv_id="Discovery World">Discovery World</channel>
-    <channel update="i" site="vg.no" site_id="77" xmltv_id="E!">E!</channel>
-    <channel update="i" site="vg.no" site_id="78" xmltv_id="Extreme Sports Channel">Extreme Sports Channel</channel>
-    <channel update="i" site="vg.no" site_id="61" xmltv_id="History Channel HD">History Channel HD</channel>
-    <channel update="i" site="vg.no" site_id="105" xmltv_id="NRK mP3">NRK mP3</channel>
-    <channel update="i" site="vg.no" site_id="102" xmltv_id="NRK Alltid Nyheter">NRK Alltid Nyheter</channel>
-    <channel update="i" site="vg.no" site_id="15" xmltv_id="SVT1 HD">SVT1 HD</channel>
-    <channel update="i" site="vg.no" site_id="17" xmltv_id="TV3">TV3</channel>
-    <channel update="i" site="vg.no" site_id="18" xmltv_id="TV8">TV8</channel>
-    <channel update="i" site="vg.no" site_id="28" xmltv_id="TV Norge HD">TV Norge HD</channel>
-    <channel update="i" site="vg.no" site_id="4" xmltv_id="Zee TV">Zee TV</channel>
-    <channel update="i" site="vg.no" site_id="5" xmltv_id="Rai 1">Rai 1</channel>
-    <channel update="i" site="vg.no" site_id="40" xmltv_id="CBS Reality">CBS Reality</channel>
-    <channel update="i" site="vg.no" site_id="43" xmltv_id="VH1">VH1</channel>
-    <channel update="i" site="vg.no" site_id="42" xmltv_id="VH1 Classic Europe">VH1 Classic Europe</channel>
-    <channel update="i" site="vg.no" site_id="41" xmltv_id="RTL">RTL</channel>
-    <channel update="i" site="vg.no" site_id="36" xmltv_id="H2 HD">H2 HD</channel>
-    <channel update="i" site="vg.no" site_id="46" xmltv_id="TV6">TV6</channel>
-    <channel update="i" site="vg.no" site_id="48" xmltv_id="Outdoor Channel HD">Outdoor Channel HD</channel>
-    <channel update="i" site="vg.no" site_id="53" xmltv_id="TV3 Plus">TV3 Plus</channel>
-    <channel update="i" site="vg.no" site_id="52" xmltv_id="TV3 (Danmark)">TV3 (Danmark)</channel>
-    <channel update="i" site="vg.no" site_id="63" xmltv_id="Viasat Film Action">Viasat Film Action</channel>
-    <channel update="i" site="vg.no" site_id="65" xmltv_id="Bravo">Bravo</channel>
-    <channel update="i" site="vg.no" site_id="66" xmltv_id="NRK Radio Super">NRK Radio Super</channel>
-    <channel update="i" site="vg.no" site_id="68" xmltv_id="Gospel Channel">Gospel Channel</channel>
-    <channel update="i" site="vg.no" site_id="69" xmltv_id="Matkanalen">Matkanalen</channel>
-    <channel update="i" site="vg.no" site_id="70" xmltv_id="Comedy Central">Comedy Central</channel>
-    <channel update="i" site="vg.no" site_id="71" xmltv_id="Investigation Discovery">Investigation Discovery</channel>
-    <channel update="i" site="vg.no" site_id="72" xmltv_id="Viasat Sport 1">Viasat Sport 1</channel>
-    <channel update="i" site="vg.no" site_id="73" xmltv_id="Viasat Sport 2">Viasat Sport 2</channel>
-    <channel update="i" site="vg.no" site_id="74" xmltv_id="Viasat Sport 3">Viasat Sport 3</channel>
-    <channel update="i" site="vg.no" site_id="75" xmltv_id="Viasat Sport Plus">Viasat Sport Plus</channel>
-    <channel update="i" site="vg.no" site_id="76" xmltv_id="TV5 Monde Europe">TV5 Monde Europe</channel>
-    <channel update="i" site="vg.no" site_id="79" xmltv_id="Visjon Norge">Visjon Norge</channel>
-    <channel update="i" site="vg.no" site_id="80" xmltv_id="NRK P1 Norgeskanalen Radio">NRK P1 Norgeskanalen Radio</channel>
-    <channel update="i" site="vg.no" site_id="108" xmltv_id="NRK P2 Kultur">NRK P2 Kultur</channel>
-    <channel update="i" site="vg.no" site_id="81" xmltv_id="NRK P3 Radio">NRK P3 Radio</channel>
-    <channel update="i" site="vg.no" site_id="82" xmltv_id="Viasat Film Family">Viasat Film Family</channel>
-    <channel update="i" site="vg.no" site_id="83" xmltv_id="Viasat History">Viasat History</channel>
-    <channel update="i" site="vg.no" site_id="64" xmltv_id="BRADPTL">BRADPTL</channel>
-    <channel update="i" site="vg.no" site_id="101" xmltv_id="Nat Geo Wild HD">Nat Geo Wild HD</channel>
-    <channel update="i" site="vg.no" site_id="104" xmltv_id="NRK Klassisk">NRK Klassisk</channel>
-    <channel update="i" site="vg.no" site_id="103" xmltv_id="NRK Jazz">NRK Jazz</channel>
-    <channel update="i" site="vg.no" site_id="100" xmltv_id="Nat Geo Wild">Nat Geo Wild</channel>
-    <channel update="i" site="vg.no" site_id="107" xmltv_id="NRK P13">NRK P13</channel>
-    <channel update="i" site="vg.no" site_id="106" xmltv_id="NRK P1 Plus">NRK P1 Plus</channel>
-    <channel update="i" site="vg.no" site_id="110" xmltv_id="P4 Radio Hele Norge">P4 Radio Hele Norge</channel>
-    <channel update="i" site="vg.no" site_id="109" xmltv_id="NRK Sami Radio">NRK Sami Radio</channel>
-    <channel update="i" site="vg.no" site_id="111" xmltv_id="Radio Norge">Radio Norge</channel>
-    <channel update="i" site="vg.no" site_id="117" xmltv_id="Viasat Explore">Viasat Explore</channel>
-    <channel update="i" site="vg.no" site_id="118" xmltv_id="Viasat Film Premiere">Viasat Film Premiere</channel>
-    <channel update="i" site="vg.no" site_id="119" xmltv_id="Viasat Film Hits">Viasat Film Hits</channel>
-    <channel update="i" site="vg.no" site_id="120" xmltv_id="Viasat Series">Viasat Series</channel>
-    <channel update="i" site="vg.no" site_id="121" xmltv_id="Viasat Golf">Viasat Golf</channel>
-    <channel update="i" site="vg.no" site_id="122" xmltv_id="Viasat Nature">Viasat Nature</channel>
-    <channel update="i" site="vg.no" site_id="124" xmltv_id="Nick Jr">Nick Jr</channel>
-    <channel update="i" site="vg.no" site_id="125" xmltv_id="Bloomberg TV HD">Bloomberg TV HD</channel>
-    <channel update="i" site="vg.no" site_id="126" xmltv_id="France 24 English HD">France 24 English HD</channel>
-    <channel update="i" site="vg.no" site_id="127" xmltv_id="Norway Live">Norway Live</channel>
+    <channel update="i" site="vg.no" site_id="nrk1" xmltv_id="NRK1">NRK1</channel>
+    <channel update="i" site="vg.no" site_id="vgtv" xmltv_id="VGTV">VGTV</channel>
+    <channel update="i" site="vg.no" site_id="nrk2" xmltv_id="NRK2">NRK2</channel>
+    <channel update="i" site="vg.no" site_id="nrk3" xmltv_id="NRK3">NRK3</channel>
+    <channel update="i" site="vg.no" site_id="tv2" xmltv_id="TV2">TV2</channel>
+    <channel update="i" site="vg.no" site_id="tvnorge" xmltv_id="TVNorge">TVNorge</channel>
+    <channel update="i" site="vg.no" site_id="tv3" xmltv_id="TV3">TV3</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-norge" xmltv_id="Eurosport Norge">Eurosport Norge</channel>
+    <channel update="i" site="vg.no" site_id="viasat-4" xmltv_id="Viasat 4">Viasat 4</channel>
+    <channel update="i" site="vg.no" site_id="matkanalen" xmltv_id="Matkanalen">Matkanalen</channel>
+    <channel update="i" site="vg.no" site_id="tv2-zebra" xmltv_id="TV2 Zebra">TV2 Zebra</channel>
+    <channel update="i" site="vg.no" site_id="tv2-nyhetskanalen" xmltv_id="TV2 Nyhetskanalen">TV2 Nyhetskanalen</channel>
+    <channel update="i" site="vg.no" site_id="tv2-sport-1" xmltv_id="TV2 Sport 1">TV2 Sport 1</channel>
+    <channel update="i" site="vg.no" site_id="tv2-sport-2" xmltv_id="TV2 Sport 2">TV2 Sport 2</channel>
+    <channel update="i" site="vg.no" site_id="tv2-livsstil" xmltv_id="TV2 Livsstil">TV2 Livsstil</channel>
+    <channel update="i" site="vg.no" site_id="max" xmltv_id="MAX">MAX</channel>
+    <channel update="i" site="vg.no" site_id="fem" xmltv_id="FEM">FEM</channel>
+    <channel update="i" site="vg.no" site_id="vox" xmltv_id="VOX">VOX</channel>
+    <channel update="i" site="vg.no" site_id="tv6-norge" xmltv_id="TV6 Norge">TV6 Norge</channel>
+    <channel update="i" site="vg.no" site_id="svt1" xmltv_id="SVT1">SVT1</channel>
+    <channel update="i" site="vg.no" site_id="svt2" xmltv_id="SVT2">SVT2</channel>
+    <channel update="i" site="vg.no" site_id="tv4" xmltv_id="TV4">TV4</channel>
+    <channel update="i" site="vg.no" site_id="mtv" xmltv_id="MTV">MTV</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-1" xmltv_id="Eurosport 1">Eurosport 1</channel>
+    <channel update="i" site="vg.no" site_id="cnn" xmltv_id="CNN">CNN</channel>
+    <channel update="i" site="vg.no" site_id="bbc-brit" xmltv_id="BBC Brit">BBC Brit</channel>
+    <channel update="i" site="vg.no" site_id="bbc-earth" xmltv_id="BBC Earth">BBC Earth</channel>
+    <channel update="i" site="vg.no" site_id="national-geographic" xmltv_id="National Geographic">National Geographic</channel>
+    <channel update="i" site="vg.no" site_id="discovery-channel" xmltv_id="Discovery Channel">Discovery Channel</channel>
+    <channel update="i" site="vg.no" site_id="tlc" xmltv_id="TLC">TLC</channel>
+    <channel update="i" site="vg.no" site_id="animal-planet" xmltv_id="Animal Planet">Animal Planet</channel>
+    <channel update="i" site="vg.no" site_id="fox-hd" xmltv_id="FOX HD">FOX HD</channel>
+    <channel update="i" site="vg.no" site_id="travel-channel" xmltv_id="Travel Channel">Travel Channel</channel>
+    <channel update="i" site="vg.no" site_id="history-channel" xmltv_id="History Channel">History Channel</channel>
+    <channel update="i" site="vg.no" site_id="nrk-super" xmltv_id="NRK Super">NRK Super</channel>
+    <channel update="i" site="vg.no" site_id="disney-channel" xmltv_id="Disney Channel">Disney Channel</channel>
+    <channel update="i" site="vg.no" site_id="nickelodeon" xmltv_id="Nickelodeon">Nickelodeon</channel>
+    <channel update="i" site="vg.no" site_id="cartoon-network" xmltv_id="Cartoon Network">Cartoon Network</channel>
+    <channel update="i" site="vg.no" site_id="tv2-sport-premium-1" xmltv_id="TV2 Sport Premium 1">TV2 Sport Premium 1</channel>
+    <channel update="i" site="vg.no" site_id="tv2-sport-premium-2" xmltv_id="TV2 Sport Premium 2">TV2 Sport Premium 2</channel>
+    <channel update="i" site="vg.no" site_id="3sat" xmltv_id="3sat">3sat</channel>
+    <channel update="i" site="vg.no" site_id="al-jazeera-english" xmltv_id="Al Jazeera English">Al Jazeera English</channel>
+    <channel update="i" site="vg.no" site_id="animal-planet-hd" xmltv_id="Animal Planet HD">Animal Planet HD</channel>
+    <channel update="i" site="vg.no" site_id="bbc-world-news" xmltv_id="BBC World News">BBC World News</channel>
+    <channel update="i" site="vg.no" site_id="boomerang" xmltv_id="Boomerang">Boomerang</channel>
+    <channel update="i" site="vg.no" site_id="c-more-stars" xmltv_id="C More Stars">C More Stars</channel>
+    <channel update="i" site="vg.no" site_id="c-more-first" xmltv_id="C More First">C More First</channel>
+    <channel update="i" site="vg.no" site_id="c-more-hits" xmltv_id="C More Hits">C More Hits</channel>
+    <channel update="i" site="vg.no" site_id="c-more-series" xmltv_id="C More Series">C More Series</channel>
+    <channel update="i" site="vg.no" site_id="sf-kanalen" xmltv_id="SF-kanalen">SF-kanalen</channel>
+    <channel update="i" site="vg.no" site_id="c-more-live-1" xmltv_id="C More Live 1">C More Live 1</channel>
+    <channel update="i" site="vg.no" site_id="c-more-hockey" xmltv_id="C More Hockey">C More Hockey</channel>
+    <channel update="i" site="vg.no" site_id="c-more-first-hd" xmltv_id="C More First HD">C More First HD</channel>
+    <channel update="i" site="vg.no" site_id="fine-living-network" xmltv_id="Fine Living Network">Fine Living Network</channel>
+    <channel update="i" site="vg.no" site_id="national-geographic-hd" xmltv_id="National Geographic HD">National Geographic HD</channel>
+    <channel update="i" site="vg.no" site_id="sat-1" xmltv_id="Sat.1">Sat.1</channel>
+    <channel update="i" site="vg.no" site_id="sky-news" xmltv_id="Sky News">Sky News</channel>
+    <channel update="i" site="vg.no" site_id="cnbc" xmltv_id="CNBC">CNBC</channel>
+    <channel update="i" site="vg.no" site_id="discovery-channel-hd" xmltv_id="Discovery Channel HD">Discovery Channel HD</channel>
+    <channel update="i" site="vg.no" site_id="disney-junior" xmltv_id="Disney Junior">Disney Junior</channel>
+    <channel update="i" site="vg.no" site_id="disney-xd" xmltv_id="Disney XD">Disney XD</channel>
+    <channel update="i" site="vg.no" site_id="dr1" xmltv_id="DR1">DR1</channel>
+    <channel update="i" site="vg.no" site_id="dr2" xmltv_id="DR2">DR2</channel>
+    <channel update="i" site="vg.no" site_id="discovery-science" xmltv_id="Discovery Science">Discovery Science</channel>
+    <channel update="i" site="vg.no" site_id="sport1" xmltv_id="SPORT1">SPORT1</channel>
+    <channel update="i" site="vg.no" site_id="tv2-danmark" xmltv_id="TV2 (Danmark)">TV2 (Danmark)</channel>
+    <channel update="i" site="vg.no" site_id="dw" xmltv_id="DW">DW</channel>
+    <channel update="i" site="vg.no" site_id="discovery-world" xmltv_id="Discovery World">Discovery World</channel>
+    <channel update="i" site="vg.no" site_id="e" xmltv_id="E!">E!</channel>
+    <channel update="i" site="vg.no" site_id="extreme-sports-channel" xmltv_id="Extreme Sports Channel">Extreme Sports Channel</channel>
+    <channel update="i" site="vg.no" site_id="history-channel-hd" xmltv_id="History Channel HD">History Channel HD</channel>
+    <channel update="i" site="vg.no" site_id="nrk-mp3" xmltv_id="NRK mP3">NRK mP3</channel>
+    <channel update="i" site="vg.no" site_id="nrk-alltid-nyheter" xmltv_id="NRK Alltid Nyheter">NRK Alltid Nyheter</channel>
+    <channel update="i" site="vg.no" site_id="svt1-hd" xmltv_id="SVT1 HD">SVT1 HD</channel>
+    <channel update="i" site="vg.no" site_id="tv3-17" xmltv_id="TV3">TV3</channel>
+    <channel update="i" site="vg.no" site_id="tv8" xmltv_id="TV8">TV8</channel>
+    <channel update="i" site="vg.no" site_id="tv-norge-hd" xmltv_id="TV Norge HD">TV Norge HD</channel>
+    <channel update="i" site="vg.no" site_id="zee-tv" xmltv_id="Zee TV">Zee TV</channel>
+    <channel update="i" site="vg.no" site_id="rai-1" xmltv_id="Rai 1">Rai 1</channel>
+    <channel update="i" site="vg.no" site_id="cbs-reality" xmltv_id="CBS Reality">CBS Reality</channel>
+    <channel update="i" site="vg.no" site_id="vh1" xmltv_id="VH1">VH1</channel>
+    <channel update="i" site="vg.no" site_id="vh1-classic-europe" xmltv_id="VH1 Classic Europe">VH1 Classic Europe</channel>
+    <channel update="i" site="vg.no" site_id="rtl" xmltv_id="RTL">RTL</channel>
+    <channel update="i" site="vg.no" site_id="h2-hd" xmltv_id="H2 HD">H2 HD</channel>
+    <channel update="i" site="vg.no" site_id="tv6" xmltv_id="TV6">TV6</channel>
+    <channel update="i" site="vg.no" site_id="outdoor-channel-hd" xmltv_id="Outdoor Channel HD">Outdoor Channel HD</channel>
+    <channel update="i" site="vg.no" site_id="tv3-plus" xmltv_id="TV3 Plus">TV3 Plus</channel>
+    <channel update="i" site="vg.no" site_id="tv3-danmark" xmltv_id="TV3 (Danmark)">TV3 (Danmark)</channel>
+    <channel update="i" site="vg.no" site_id="viasat-film-action" xmltv_id="Viasat Film Action">Viasat Film Action</channel>
+    <channel update="i" site="vg.no" site_id="bravo" xmltv_id="Bravo">Bravo</channel>
+    <channel update="i" site="vg.no" site_id="nrk-radio-super" xmltv_id="NRK Radio Super">NRK Radio Super</channel>
+    <channel update="i" site="vg.no" site_id="gospel-channel" xmltv_id="Gospel Channel">Gospel Channel</channel>
+    <channel update="i" site="vg.no" site_id="investigation-discovery" xmltv_id="Investigation Discovery">Investigation Discovery</channel>
+    <channel update="i" site="vg.no" site_id="viasport-1" xmltv_id="Viasport 1">Viasport 1</channel>
+    <channel update="i" site="vg.no" site_id="viasport-2" xmltv_id="Viasport 2">Viasport 2</channel>
+    <channel update="i" site="vg.no" site_id="viasport-3" xmltv_id="Viasport 3">Viasport 3</channel>
+    <channel update="i" site="vg.no" site_id="viasport-plus" xmltv_id="Viasport Plus">Viasport Plus</channel>
+    <channel update="i" site="vg.no" site_id="tv5-monde-europe" xmltv_id="TV5 Monde Europe">TV5 Monde Europe</channel>
+    <channel update="i" site="vg.no" site_id="visjon-norge" xmltv_id="Visjon Norge">Visjon Norge</channel>
+    <channel update="i" site="vg.no" site_id="nrk-p1-norgeskanalen-radio" xmltv_id="NRK P1 Norgeskanalen Radio">NRK P1 Norgeskanalen Radio</channel>
+    <channel update="i" site="vg.no" site_id="nrk-p2-kultur" xmltv_id="NRK P2 Kultur">NRK P2 Kultur</channel>
+    <channel update="i" site="vg.no" site_id="nrk-p3-radio" xmltv_id="NRK P3 Radio">NRK P3 Radio</channel>
+    <channel update="i" site="vg.no" site_id="viasat-film-family" xmltv_id="Viasat Film Family">Viasat Film Family</channel>
+    <channel update="i" site="vg.no" site_id="viasat-history" xmltv_id="Viasat History">Viasat History</channel>
+    <channel update="i" site="vg.no" site_id="bradptl" xmltv_id="BRADPTL">BRADPTL</channel>
+    <channel update="i" site="vg.no" site_id="national-geographic-wild-hd" xmltv_id="National Geographic Wild HD">National Geographic Wild HD</channel>
+    <channel update="i" site="vg.no" site_id="nrk-klassisk" xmltv_id="NRK Klassisk">NRK Klassisk</channel>
+    <channel update="i" site="vg.no" site_id="nrk-jazz" xmltv_id="NRK Jazz">NRK Jazz</channel>
+    <channel update="i" site="vg.no" site_id="national-geographic-wild" xmltv_id="National Geographic Wild">National Geographic Wild</channel>
+    <channel update="i" site="vg.no" site_id="nrk-p13" xmltv_id="NRK P13">NRK P13</channel>
+    <channel update="i" site="vg.no" site_id="nrk-p1-plus" xmltv_id="NRK P1 Plus">NRK P1 Plus</channel>
+    <channel update="i" site="vg.no" site_id="p4-radio-hele-norge" xmltv_id="P4 Radio Hele Norge">P4 Radio Hele Norge</channel>
+    <channel update="i" site="vg.no" site_id="nrk-sami-radio" xmltv_id="NRK Sami Radio">NRK Sami Radio</channel>
+    <channel update="i" site="vg.no" site_id="radio-norge" xmltv_id="Radio Norge">Radio Norge</channel>
+    <channel update="i" site="vg.no" site_id="viasat-explore" xmltv_id="Viasat Explore">Viasat Explore</channel>
+    <channel update="i" site="vg.no" site_id="viasat-film-premiere" xmltv_id="Viasat Film Premiere">Viasat Film Premiere</channel>
+    <channel update="i" site="vg.no" site_id="viasat-film-hits" xmltv_id="Viasat Film Hits">Viasat Film Hits</channel>
+    <channel update="i" site="vg.no" site_id="viasat-series" xmltv_id="Viasat Series">Viasat Series</channel>
+    <channel update="i" site="vg.no" site_id="viasat-golf" xmltv_id="Viasat Golf">Viasat Golf</channel>
+    <channel update="i" site="vg.no" site_id="viasat-nature" xmltv_id="Viasat Nature">Viasat Nature</channel>
+    <channel update="i" site="vg.no" site_id="nick-jr" xmltv_id="Nick Jr">Nick Jr</channel>
+    <channel update="i" site="vg.no" site_id="bloomberg-tv-hd" xmltv_id="Bloomberg TV HD">Bloomberg TV HD</channel>
+    <channel update="i" site="vg.no" site_id="france-24-english-hd" xmltv_id="France 24 English HD">France 24 English HD</channel>
+    <channel update="i" site="vg.no" site_id="norway-live" xmltv_id="Norway Live">Norway Live</channel>
+    <channel update="i" site="vg.no" site_id="motorvision-tv" xmltv_id="Motorvision TV">Motorvision TV</channel>
+    <channel update="i" site="vg.no" site_id="nicktoons" xmltv_id="Nicktoons">Nicktoons</channel>
+    <channel update="i" site="vg.no" site_id="blue-hustler" xmltv_id="Blue Hustler">Blue Hustler</channel>
+    <channel update="i" site="vg.no" site_id="kunskapskanalen" xmltv_id="Kunskapskanalen">Kunskapskanalen</channel>
+    <channel update="i" site="vg.no" site_id="trace-urban-hd" xmltv_id="Trace Urban HD">Trace Urban HD</channel>
+    <channel update="i" site="vg.no" site_id="motorvision-tv-133" xmltv_id="Motorvision TV">Motorvision TV</channel>
+    <channel update="i" site="vg.no" site_id="esportstv-hd" xmltv_id="eSportsTV HD">eSportsTV HD</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-1" xmltv_id="Eurosport Pluss 1">Eurosport Pluss 1</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-2" xmltv_id="Eurosport Pluss 2">Eurosport Pluss 2</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-3" xmltv_id="Eurosport Pluss 3">Eurosport Pluss 3</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-4" xmltv_id="Eurosport Pluss 4">Eurosport Pluss 4</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-5" xmltv_id="Eurosport Pluss 5">Eurosport Pluss 5</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-6" xmltv_id="Eurosport Pluss 6">Eurosport Pluss 6</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-7" xmltv_id="Eurosport Pluss 7">Eurosport Pluss 7</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-8" xmltv_id="Eurosport Pluss 8">Eurosport Pluss 8</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-9" xmltv_id="Eurosport Pluss 9">Eurosport Pluss 9</channel>
+    <channel update="i" site="vg.no" site_id="eurosport-pluss-10" xmltv_id="Eurosport Pluss 10">Eurosport Pluss 10</channel>
+    <channel update="i" site="vg.no" site_id="strive-sport-tv" xmltv_id="Strive Sport TV">Strive Sport TV</channel>
   </channels>
 </site>

--- a/siteini.pack/Norway/vg.no.ini
+++ b/siteini.pack/Norway/vg.no.ini
@@ -1,10 +1,11 @@
-﻿**------------------------------------------------------------------------------------------------
 **------------------------------------------------------------------------------------------------
 * @header_start
 * WebGrab+Plus ini for grabbing EPG data from TvGuide websites
 * @Site: vg.no
 * @MinSWversion: V2.1
-*   
+*
+* @Revision 8 - [19/03/2020] Maniac
+*   API has changed, similar to tv.nu.ini with some modifications
 * @Revision 7 - [13/02/2010] doglover
 *   Site change
 * @Revision 6 - [21/12/2018] Goran
@@ -24,36 +25,66 @@
 *   a Norwegian site
 * @header_end
 **------------------------------------------------------------------------------------------------
-
-site {url=vg.no|timezone=UTC|maxdays=7|cultureinfo=nb-NO|charset=UTF-8|ratingsystem=IMDB|titlematchfactor=90|allowlastdayoverflow}
-url_index{url|https://web-api.tvno.nu/tableau/schedule?channelId[]=|channel|&date=|urldate}
+site {url=tvguide.vg.no|timezone=UTC|maxdays=7|cultureinfo=nb-NO|charset=UTF-8|titlematchfactor=90|ratingsystem=imdb|allowlastdayoverflow}
+*site {episodesystem=xmltv_ns}
+site {episodesystem=onscreen}
 urldate.format {datestring|yyyy-MM-dd}
-index_showsplit.scrub {multi |"type"|||}
-index_temp_1.scrub {url|https://web-api.tvno.nu/details/broadcast/|broadcastId":"||"|}
-index_urlshow {url|https://web-api.tvno.nu/details/broadcast/|id":"||"|}
-index_urlshow.modify {addend (not"")|?compact=true}
-index_urlshow.modify {replace ('index_temp_1' not"")|'index_urlshow'|'index_temp_1'}
-index_start.scrub {regex||"startTime":(\d{10})||}
-index_stop.scrub {regex||"endTime":(\d{10})||}
-index_title.scrub {single|"title":"||","}
+url_index{url|https://web-api.tvno.nu/channels/|channel|/schedule?date=|urldate|&fullDay=true}
+url_index.headers {customheader=X-Requested-With=XMLHttpRequest}
+index_urlchannellogo {url||"image":"||","broadcasts"}
+scope.range {(splitindex)|end}
+index_showsplit.scrub {multi|"broadcasts":[|{"type":||],"channelPlayProvider"}
+index_showsplit.modify{replace|\}\}\},\{|\}\|\{}
+index_showsplit.modify {cleanup(style=unidecode)}
+end_scope
+scope.range {(indexshowdetails)|end}
+index_start.scrub {regex||"startTime":(\d*)||}
+index_stop.scrub {regex||"endTime":(\d*)||}
+index_title.scrub {single|"title":"||",|",}
+global_temp_1.scrub {single|"description":"||",|",}
+index_showicon.scrub{url||"imageLandscape":"||",|",}
+index_rating.scrub{single|"imdb":{"rating":"||"|"}
+index_productiondate.scrub{single|"year":||,"}
+index_category.scrub{single(separator="","")|"genres":["||"],}
+index_temp_1.scrub{regex||^"([^",]*)","id":||}
+*index_temp_2.scrub{regex||^".*?","id":"([^",]*)","slug||}
+*index_temp_1.modify{addend|/'index_temp_2'}
+end_scope
+index_urlshow.modify {addstart('index_temp_1' not "")|https://web-api.tvno.nu/details/broadcast/'index_temp_1'}
+index_urlshow.modify{addend(not "")|?compact=true}
+index_urlshow.headers {customheader=Accept-Encoding=gzip,deflate}     * to speedup the downloading of the detail pages
+scope.range {(showdetails)|end}
+title.modify{addstart|'index_title'}
+subtitle.scrub {single|"title":"||",|",}
+description.modify {addend('description' "")|'global_temp_1'}
+description.modify {replace|\\"|"}
+country.scrub{single(separator="","")|"countries":["||"]}
+producer.scrub {multi(max=2 includeblock="Produsent""Exekutiv producent")|{"name":"||","|}}
+director.scrub {multi(max=2 includeblock="Regissør")|{"name":"||","|}}
+actor.scrub {multi(max=4 includeblock="Skuespiller""Guest Star")|{"name":"||","|}}
+writer.scrub {multi(max=2 includeblock="Forfatter""Manusforfatter")|{"name":"||","|}}
+presenter.scrub {multi(max=2 includeblock="Programleder""Forteller")|{"name":"||","|}}
+temp_1.scrub{regex||^.*?"seasonNumber":([+-]?\d*)||}
+temp_1.modify{addstart(not "")|S}
+temp_2.scrub{regex(include=first)||^.*?"episodeNumber":([+-]?\d*)||}
+temp_2.modify{addstart(not "")|E}
+temp_3.scrub{regex||"totalEpisodes":(\d+),||}
+temp_3.modify{addstart(not "")|Et}
+episode.modify {addstart(pattern="S'S1'E'E1'Et'Et1'""S'S1'""E'E1'""Et'Et1'")|'temp_1''temp_2''temp_3'}
+end_scope
+subtitle.modify{remove( ~'index_title')|'subtitle'}
+temp_4.scrub {single|"tournament":"||",|",}
+subtitle.modify{addend(not "")| ('temp_4')}
 *
-title.modify {addstart|'index_title'}
-description.scrub {single|"description|":"|","|}
-category.scrub {multi(separator="\",\"")|"genres":["||"]|}
-rating.scrub {single|"imdb":{"rating":"||","|}
-country.scrub {single|"countries":["||"]}
-actor.scrub {regex ||\{"name":"([^"]*?)","slug":"[^"]*","role":"Skuespiller"||}
-presenter.scrub {regex ||\{"name":"([^"]*?)","slug":"[^"]*","role":"Vert"||}
-episode.scrub { single(pattern="episodeNumber":'E1',"seasonNumber":'S1'""episodeNumber":'E1'""seasonNumber":'S1'")|"episodeId":"|","|}|}}
-description.modify {cleanup(style=jsondecode)}
-episode.modify {replace|episodeNumber":|E}
-episode.modify {replace|"seasonNumber":|S}
 *
 **  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _  _
 **      #####  CHANNEL FILE CREATION (only to create the xxx-channel.xml file)
 **
 ** @auto_xml_channel_start
-*url_index {url|https://web-api.tvno.nu/channels/}
-*index_site_channel.scrub {multi|"name":"||","|}
-*index_site_id.scrub {multi|"id":||,"name"|}
+*url_index{url|https://web-api.tvno.nu/channels}
+*index_site_id.scrub {regex||{"id":\d+,"name":".*?","slug":"([^"]*)","||}
+*index_site_channel.scrub {regex||{"id":\d+,"name":"([^"]*)","slug":"||}
+*scope.range {(channellist)|end}
+*index_site_id.modify {cleanup(removeduplicates=equal,100 link="index_site_channel")}
+*end_scope
 ** @auto_xml_channel_end


### PR DESCRIPTION
Got vg.no guide working again. It is basically same as tv.nu.ini but with some minor differences. For some reason it doesn't fetch/parse show details even tho the api-url is correct. Don't see this as a big deal as it only parses actors/directors from the details page.