### PR TITLE
blue Sport UHD stations marked

### DIFF
--- a/siteini.pack/Switzerland/tv.blue.ch.channels.xml
+++ b/siteini.pack/Switzerland/tv.blue.ch.channels.xml
@@ -256,10 +256,10 @@
     <channel update="i" site="tv.blue.ch" site_id="1432##188b74d9-4cc1-2300-7048-558b4775e351" xmltv_id="blue Sport 39">blue Sport 39</channel>
     <channel update="i" site="tv.blue.ch" site_id="1433##27cb38d9-4cc1-2300-7048-558b4775e345" xmltv_id="blue Sport 40">blue Sport 40</channel>
     <channel update="i" site="tv.blue.ch" site_id="1442##132f2c15-4cc1-2300-7048-558b4775e320" xmltv_id="blue Sport 41">blue Sport 41</channel>
-    <channel update="i" site="tv.blue.ch" site_id="1000##a853a4f2-ff63-5200-7048-d8d59d805f7a" xmltv_id="blue Sport 1">blue Sport 1</channel>
-    <channel update="i" site="tv.blue.ch" site_id="1249##576d1686-08d3-3200-7048-6f8d6c717c45" xmltv_id="blue Sport 2">blue Sport 2</channel>
-    <channel update="i" site="tv.blue.ch" site_id="1250##53be1a86-08d3-3200-7048-6f8d6c717c8e" xmltv_id="blue Sport 3">blue Sport 3</channel>
-    <channel update="i" site="tv.blue.ch" site_id="1440##89b90b27-74b0-6300-7048-67d39e2bc499" xmltv_id="blue Sport 4">blue Sport 4</channel>
+    <channel update="i" site="tv.blue.ch" site_id="1000##a853a4f2-ff63-5200-7048-d8d59d805f7a" xmltv_id="blue Sport 1 UHD">blue Sport 1 UHD</channel>
+    <channel update="i" site="tv.blue.ch" site_id="1249##576d1686-08d3-3200-7048-6f8d6c717c45" xmltv_id="blue Sport 2 UHD">blue Sport 2 UHD</channel>
+    <channel update="i" site="tv.blue.ch" site_id="1250##53be1a86-08d3-3200-7048-6f8d6c717c8e" xmltv_id="blue Sport 3 UHD">blue Sport 3 UHD</channel>
+    <channel update="i" site="tv.blue.ch" site_id="1440##89b90b27-74b0-6300-7048-67d39e2bc499" xmltv_id="blue Sport 4 UHD">blue Sport 4 UHD</channel>
     <channel update="i" site="tv.blue.ch" site_id="1036##2d61e4b4-bf45-2200-7048-bdbaa361d096" xmltv_id="RMC Sport Access 1">RMC Sport Access 1</channel>
     <channel update="i" site="tv.blue.ch" site_id="250##03b87e1b-4c77-411f-b66b-a279d66eb2c7" xmltv_id="RMC Sport Access 2">RMC Sport Access 2</channel>
     <channel update="i" site="tv.blue.ch" site_id="264##ddf565d1-da87-4a2d-90ce-a459c8009801" xmltv_id="Motorvision TV">Motorvision TV</channel>


### PR DESCRIPTION
'blue Sport 1 UHD' had the same tvg-id as 'blue Sport 1'. Seperated according to https://tv.blue.ch/tv-guide.