### PR TITLE
Pluto TV DACH update

### DIFF
--- a/siteini.pack/Networks/pluto.tv.E.channels.xml
+++ b/siteini.pack/Networks/pluto.tv.E.channels.xml
@@ -379,6 +379,7 @@
     <channel update="i" site="pluto.tv.E" site_id="5ce40e59246a395e9758923e" xmltv_id="Inside">Inside</channel>
     <channel update="i" site="pluto.tv.E" site_id="5db048f9447d6c0009b8f29d" xmltv_id="Documentaries">Documentaries</channel>
     <channel update="i" site="pluto.tv.E" site_id="60e4519e6873180007d3cddb" xmltv_id="BBC Travel">BBC Travel</channel>
+    <channel update="i" site="pluto.tv.E" site_id="5d767b4889bca2ce7b73ef2e" xmltv_id="Science">Science</channel>
     <channel update="i" site="pluto.tv.E" site_id="60ed498c4248a400077c0b9d" xmltv_id="SciFi">SciFi</channel>
     <channel update="i" site="pluto.tv.E" site_id="5be1c3f9851dd5632e2c91b2" xmltv_id="Nature">Nature</channel>
     <channel update="i" site="pluto.tv.E" site_id="61409f8d6feb30000766b675" xmltv_id="Space">Space</channel>
@@ -386,7 +387,6 @@
     <channel update="i" site="pluto.tv.E" site_id="5ad9b8551b95267e225e59c1" xmltv_id="Explore">Explore</channel>
     <channel update="i" site="pluto.tv.E" site_id="61409b5108ae6e0007f9b189" xmltv_id="Biografie">Biografie</channel>
     <channel update="i" site="pluto.tv.E" site_id="5f3bd0e63f793300071574cd" xmltv_id="Focus TV Reportage">Focus TV Reportage</channel>
-    <channel update="i" site="pluto.tv.E" site_id="5e1efd0dbbe3ba000908b639" xmltv_id="Sitcoms">Sitcoms</channel>
     <channel update="i" site="pluto.tv.E" site_id="6054a9f4bc8a5f000771504c" xmltv_id="Takeshi's Castle">Takeshi's Castle</channel>
     <channel update="i" site="pluto.tv.E" site_id="5d4947590ba40f75dc29c26b" xmltv_id="Comedy Central Pluto">Comedy Central Pluto</channel>
     <channel update="i" site="pluto.tv.E" site_id="5d4948418101147596fd6c5a" xmltv_id="Comedy Central Made in Germany">Comedy Central Made in Germany</channel>


### PR DESCRIPTION
Science added, 'Sitcoms' removed: Channel was replaced by 'Comedy' - was a duplicate in here.