### PR TITLE
Addition of 8 new channels

### DIFF
--- a/siteini.pack/France/dazn.com.channels.xml
+++ b/siteini.pack/France/dazn.com.channels.xml
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <site generator-info-name="WebGrab+Plus/w MDB &amp; REX Postprocess -- version V5.1.4.0 -- Jan van Straaten" site="dazn.com">
   <channels>
-    <channel update="f" site="dazn.com" site_id="DAZNLigue1.fr" xmltv_id="DAZNLigue1.fr">DAZN Ligue 1</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1.fr" xmltv_id="DAZNLigue1.fr">DAZN Ligue 1 - Tous les matchs</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M1.fr" xmltv_id="DAZNLigue1-M1.fr">DAZN Ligue 1 - Match du vendredi 20h45</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M2.fr" xmltv_id="DAZNLigue1-M2.fr">DAZN Ligue 1 - Match du samedi 19h00</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M3.fr" xmltv_id="DAZNLigue1-M3.fr">DAZN Ligue 1 - Match du samedi 21h00</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M4.fr" xmltv_id="DAZNLigue1-M4.fr">DAZN Ligue 1 - Match du dimanche 15h00</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M5.fr" xmltv_id="DAZNLigue1-M5.fr">DAZN Ligue 1 - Match 1 du Multiplex du dimanche 17h00</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M6.fr" xmltv_id="DAZNLigue1-M6.fr">DAZN Ligue 1 - Match 2 du Multiplex du dimanche 17h00</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M7.fr" xmltv_id="DAZNLigue1-M7.fr">DAZN Ligue 1 - Match 3 du Multiplex du dimanche 17h00</channel>
+    <channel update="f" site="dazn.com" site_id="DAZNLigue1-M8.fr" xmltv_id="DAZNLigue1-M8.fr">DAZN Ligue 1 - Match du dimanche 20h45</channel>
   </channels>
 </site>


### PR DESCRIPTION
8 separate channels for each match schedule per day:
- Friday match 8.45 pm -> DAZNLigue1-M1.fr
- Saturday match 7:00 pm -> DAZNLigue1-M2.fr
- Saturday match 9:00 pm -> DAZNLigue1-M3.fr
- Sunday match 3:00 pm -> DAZNLigue1-M4.fr
- Sunday match Multiplex 1  5:00 pm -> DAZNLigue1-M5.fr
- Sunday match Multiplex 2 Sunday 5:00 pm -> DAZNLigue1-M6.fr
- Sunday match Multiplex 3 Sunday 5:00 pm -> DAZNLigue1-M7.fr
- Sunday match 8.45 pm -> DAZNLigue1-M8.fr